### PR TITLE
feat(front): add business management feature

### DIFF
--- a/front/central-next-js/src/app/admin-businesses/page.tsx
+++ b/front/central-next-js/src/app/admin-businesses/page.tsx
@@ -1,0 +1,1 @@
+export { default } from '@/features/business/ui/pages/BusinessPage';

--- a/front/central-next-js/src/features/business/adapters/http/BusinessRepositoryHttp.ts
+++ b/front/central-next-js/src/features/business/adapters/http/BusinessRepositoryHttp.ts
@@ -1,0 +1,21 @@
+import { BusinessRepository } from '@/features/business/ports/BusinessRepository';
+import { BusinessListDTO } from '@/features/business/domain/Business';
+import { BusinessService } from './BusinessService';
+
+export class BusinessRepositoryHttp implements BusinessRepository {
+  private service: BusinessService;
+
+  constructor() {
+    this.service = new BusinessService();
+  }
+
+  async getBusinesses(): Promise<BusinessListDTO> {
+    const result = await this.service.getBusinesses();
+    return {
+      businesses: result.businesses || [],
+      total: result.total || 0,
+      page: result.page || 1,
+      limit: result.limit || 10,
+    };
+  }
+}

--- a/front/central-next-js/src/features/business/adapters/http/BusinessService.ts
+++ b/front/central-next-js/src/features/business/adapters/http/BusinessService.ts
@@ -1,0 +1,21 @@
+import { HttpClient } from '@/shared/adapters/http/HttpClient';
+import { config } from '@/shared/config/env';
+
+export class BusinessService {
+  private httpClient: HttpClient;
+
+  constructor() {
+    this.httpClient = new HttpClient(config.API_BASE_URL);
+    console.log('BusinessService initialized with base URL:', config.API_BASE_URL);
+  }
+
+  async getBusinesses() {
+    try {
+      const response = await this.httpClient.get('/api/v1/businesses');
+      return response.data || { businesses: [], total: 0, page: 1, limit: 10 };
+    } catch (error) {
+      console.error('BusinessService: Error getting businesses:', error);
+      throw error;
+    }
+  }
+}

--- a/front/central-next-js/src/features/business/application/GetBusinessesUseCase.ts
+++ b/front/central-next-js/src/features/business/application/GetBusinessesUseCase.ts
@@ -1,0 +1,16 @@
+import { BusinessRepository } from '@/features/business/ports/BusinessRepository';
+import { BusinessListDTO } from '@/features/business/domain/Business';
+
+export class GetBusinessesUseCase {
+  constructor(private businessRepository: BusinessRepository) {}
+
+  async execute(): Promise<BusinessListDTO> {
+    try {
+      const result = await this.businessRepository.getBusinesses();
+      return result;
+    } catch (error) {
+      console.error('GetBusinessesUseCase: Error:', error);
+      return { businesses: [], total: 0, page: 1, limit: 10 };
+    }
+  }
+}

--- a/front/central-next-js/src/features/business/domain/Business.ts
+++ b/front/central-next-js/src/features/business/domain/Business.ts
@@ -1,0 +1,33 @@
+// Domain - Business Entity
+export interface BusinessType {
+  id: number;
+  name: string;
+  code: string;
+}
+
+export interface Business {
+  id: number;
+  name: string;
+  code: string;
+  businessType: BusinessType;
+  timezone?: string;
+  address?: string;
+  description?: string;
+  logoURL?: string;
+  primaryColor?: string;
+  secondaryColor?: string;
+  customDomain?: string;
+  isActive: boolean;
+  enableDelivery?: boolean;
+  enablePickup?: boolean;
+  enableReservations?: boolean;
+  createdAt?: string;
+  updatedAt?: string;
+}
+
+export interface BusinessListDTO {
+  businesses: Business[];
+  total: number;
+  page: number;
+  limit: number;
+}

--- a/front/central-next-js/src/features/business/ports/BusinessRepository.ts
+++ b/front/central-next-js/src/features/business/ports/BusinessRepository.ts
@@ -1,0 +1,5 @@
+import { BusinessListDTO } from '@/features/business/domain/Business';
+
+export interface BusinessRepository {
+  getBusinesses(): Promise<BusinessListDTO>;
+}

--- a/front/central-next-js/src/features/business/ui/hooks/useBusinesses.ts
+++ b/front/central-next-js/src/features/business/ui/hooks/useBusinesses.ts
@@ -1,0 +1,28 @@
+import { useState, useCallback, useMemo } from 'react';
+import { Business } from '@/features/business/domain/Business';
+import { BusinessRepositoryHttp } from '@/features/business/adapters/http/BusinessRepositoryHttp';
+import { GetBusinessesUseCase } from '@/features/business/application/GetBusinessesUseCase';
+
+export const useBusinesses = () => {
+  const [businesses, setBusinesses] = useState<Business[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const repository = useMemo(() => new BusinessRepositoryHttp(), []);
+  const useCase = useMemo(() => new GetBusinessesUseCase(repository), [repository]);
+
+  const loadBusinesses = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const result = await useCase.execute();
+      setBusinesses(result.businesses);
+    } catch (err: any) {
+      setError(err.message);
+    } finally {
+      setLoading(false);
+    }
+  }, [useCase]);
+
+  return { businesses, loading, error, loadBusinesses };
+};

--- a/front/central-next-js/src/features/business/ui/pages/BusinessPage.css
+++ b/front/central-next-js/src/features/business/ui/pages/BusinessPage.css
@@ -1,0 +1,81 @@
+.business-page {
+  min-height: 100vh;
+  background-color: #f8f9fa;
+  padding: 20px;
+}
+
+.page-header {
+  background: white;
+  padding: 20px;
+  border-radius: 12px;
+  box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+  margin-bottom: 30px;
+}
+
+.header-content h1 {
+  margin: 0 0 8px 0;
+  color: var(--foreground, #111827);
+  font-size: 2rem;
+  font-weight: 700;
+}
+
+.header-content p {
+  margin: 0;
+  color: var(--foreground, #6b7280);
+  font-size: 1rem;
+}
+
+.table-container {
+  background: white;
+  border-radius: 12px;
+  overflow: hidden;
+  box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+}
+
+.business-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.business-table th {
+  background: linear-gradient(135deg, var(--primary-color, #3b82f6) 0%, var(--secondary-color, #10b981) 100%);
+  color: white;
+  padding: 16px 12px;
+  text-align: left;
+  font-weight: 600;
+  font-size: 0.9rem;
+}
+
+.business-table td {
+  padding: 16px 12px;
+  border-bottom: 1px solid #f3f4f6;
+}
+
+.business-logo-cell {
+  width: 50px;
+  height: 50px;
+  border-radius: 8px;
+  overflow: hidden;
+  background-color: #f3f4f6;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.business-logo-img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.business-logo-placeholder {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: linear-gradient(135deg, var(--secondary-color, #10b981) 0%, var(--primary-color, #3b82f6) 100%);
+  color: white;
+  font-weight: 700;
+  font-size: 1.2rem;
+}

--- a/front/central-next-js/src/features/business/ui/pages/BusinessPage.tsx
+++ b/front/central-next-js/src/features/business/ui/pages/BusinessPage.tsx
@@ -1,0 +1,77 @@
+'use client';
+
+import React, { useEffect } from 'react';
+import Layout from '@/shared/ui/components/Layout';
+import LoadingSpinner from '@/shared/ui/components/LoadingSpinner';
+import { useBusinesses } from '../hooks/useBusinesses';
+import './BusinessPage.css';
+
+export default function BusinessPage() {
+  const { businesses, loading, error, loadBusinesses } = useBusinesses();
+
+  useEffect(() => {
+    loadBusinesses();
+  }, [loadBusinesses]);
+
+  return (
+    <Layout>
+      <div className="business-page">
+        <div className="page-header">
+          <div className="header-content">
+            <h1>Administrar Negocios</h1>
+            <p>Listado de negocios disponibles</p>
+          </div>
+        </div>
+
+        {loading && (
+          <div className="loading-container">
+            <LoadingSpinner />
+          </div>
+        )}
+
+        {error && (
+          <div className="error-container">
+            <p>{error}</p>
+          </div>
+        )}
+
+        {!loading && !error && (
+          <div className="table-container">
+            <table className="business-table">
+              <thead>
+                <tr>
+                  <th>Logo</th>
+                  <th>Nombre</th>
+                  <th>Tipo</th>
+                </tr>
+              </thead>
+              <tbody>
+                {businesses.map((business) => (
+                  <tr key={business.id}>
+                    <td>
+                      <div className="business-logo-cell">
+                        {business.logoURL && business.logoURL.trim() !== '' ? (
+                          <img
+                            src={`https://media.xn--rup-joa.com/${business.logoURL}`}
+                            alt={business.name}
+                            className="business-logo-img"
+                          />
+                        ) : (
+                          <span className="business-logo-placeholder">
+                            {business.name.charAt(0).toUpperCase()}
+                          </span>
+                        )}
+                      </div>
+                    </td>
+                    <td>{business.name}</td>
+                    <td>{business.businessType?.name || '-'}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+    </Layout>
+  );
+}


### PR DESCRIPTION
## Summary
- add business domain, repository, and use case to retrieve businesses
- display business list with themed styles and logos

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689a4f9fb054832b9b971f894b1d5b84