### PR TITLE
feat: add clients module to central-next-js

### DIFF
--- a/front/central-next-js/src/app/clients/page.tsx
+++ b/front/central-next-js/src/app/clients/page.tsx
@@ -1,0 +1,1 @@
+export { default } from '@/features/clients/ui/pages/ClientsPage';

--- a/front/central-next-js/src/features/clients/adapters/http/ClientRepositoryHttp.ts
+++ b/front/central-next-js/src/features/clients/adapters/http/ClientRepositoryHttp.ts
@@ -1,0 +1,31 @@
+import { ClientRepository } from '@/features/clients/ports/ClientRepository';
+import { Client, CreateClientDTO, UpdateClientDTO } from '@/features/clients/domain/Client';
+import { ClientService } from './ClientService';
+
+export class ClientRepositoryHttp implements ClientRepository {
+  private service: ClientService;
+
+  constructor() {
+    this.service = new ClientService();
+  }
+
+  async getClients(): Promise<Client[]> {
+    return await this.service.getClients();
+  }
+
+  async getClientById(id: number): Promise<Client> {
+    return await this.service.getClientById(id);
+  }
+
+  async createClient(data: CreateClientDTO): Promise<{ success: boolean; message?: string }> {
+    return await this.service.createClient(data);
+  }
+
+  async updateClient(id: number, data: UpdateClientDTO): Promise<{ success: boolean; message?: string }> {
+    return await this.service.updateClient(id, data);
+  }
+
+  async deleteClient(id: number): Promise<{ success: boolean; message?: string }> {
+    return await this.service.deleteClient(id);
+  }
+}

--- a/front/central-next-js/src/features/clients/adapters/http/ClientService.ts
+++ b/front/central-next-js/src/features/clients/adapters/http/ClientService.ts
@@ -1,0 +1,64 @@
+import { HttpClient } from '@/shared/adapters/http/HttpClient';
+import { config } from '@/shared/config/env';
+import { Client, CreateClientDTO, UpdateClientDTO } from '@/features/clients/domain/Client';
+
+export class ClientService {
+  private httpClient: HttpClient;
+
+  constructor() {
+    this.httpClient = new HttpClient(config.API_BASE_URL);
+  }
+
+  async getClients(): Promise<Client[]> {
+    const response = await this.httpClient.get('/api/v1/clients');
+    const data = response.data || response.clients || response;
+    return Array.isArray(data) ? data.map(this.mapClientFromBackend) : [];
+  }
+
+  async getClientById(id: number): Promise<Client> {
+    const response = await this.httpClient.get(`/api/v1/clients/${id}`);
+    const data = response.data || response.client || response;
+    return this.mapClientFromBackend(data);
+  }
+
+  async createClient(client: CreateClientDTO): Promise<{ success: boolean; message?: string }> {
+    const response = await this.httpClient.post('/api/v1/clients', {
+      business_id: client.businessID,
+      name: client.name,
+      email: client.email,
+      phone: client.phone,
+      dni: client.dni
+    });
+    return { success: response.success !== false, message: response.message || 'Client created successfully' };
+  }
+
+  async updateClient(id: number, client: UpdateClientDTO): Promise<{ success: boolean; message?: string }> {
+    const response = await this.httpClient.put(`/api/v1/clients/${id}`, {
+      business_id: client.businessID,
+      name: client.name,
+      email: client.email,
+      phone: client.phone,
+      dni: client.dni
+    });
+    return { success: response.success !== false, message: response.message || 'Client updated successfully' };
+  }
+
+  async deleteClient(id: number): Promise<{ success: boolean; message?: string }> {
+    const response = await this.httpClient.delete(`/api/v1/clients/${id}`);
+    return { success: response.success !== false, message: response.message || 'Client deleted successfully' };
+  }
+
+  private mapClientFromBackend(backend: any): Client {
+    return {
+      id: backend.id,
+      businessID: backend.business_id,
+      name: backend.name,
+      email: backend.email,
+      phone: backend.phone,
+      dni: backend.dni,
+      createdAt: backend.created_at,
+      updatedAt: backend.updated_at,
+      deletedAt: backend.deleted_at
+    };
+  }
+}

--- a/front/central-next-js/src/features/clients/application/CreateClientUseCase.ts
+++ b/front/central-next-js/src/features/clients/application/CreateClientUseCase.ts
@@ -1,0 +1,15 @@
+import { ClientRepository } from '@/features/clients/ports/ClientRepository';
+import { CreateClientDTO } from '@/features/clients/domain/Client';
+
+export class CreateClientUseCase {
+  constructor(private repository: ClientRepository) {}
+
+  async execute(data: CreateClientDTO): Promise<{ success: boolean; message?: string }> {
+    try {
+      return await this.repository.createClient(data);
+    } catch (error) {
+      console.error('CreateClientUseCase: Error:', error);
+      throw error;
+    }
+  }
+}

--- a/front/central-next-js/src/features/clients/application/DeleteClientUseCase.ts
+++ b/front/central-next-js/src/features/clients/application/DeleteClientUseCase.ts
@@ -1,0 +1,14 @@
+import { ClientRepository } from '@/features/clients/ports/ClientRepository';
+
+export class DeleteClientUseCase {
+  constructor(private repository: ClientRepository) {}
+
+  async execute(id: number): Promise<{ success: boolean; message?: string }> {
+    try {
+      return await this.repository.deleteClient(id);
+    } catch (error) {
+      console.error('DeleteClientUseCase: Error:', error);
+      throw error;
+    }
+  }
+}

--- a/front/central-next-js/src/features/clients/application/GetClientsUseCase.ts
+++ b/front/central-next-js/src/features/clients/application/GetClientsUseCase.ts
@@ -1,0 +1,15 @@
+import { Client } from '@/features/clients/domain/Client';
+import { ClientRepository } from '@/features/clients/ports/ClientRepository';
+
+export class GetClientsUseCase {
+  constructor(private repository: ClientRepository) {}
+
+  async execute(): Promise<Client[]> {
+    try {
+      return await this.repository.getClients();
+    } catch (error) {
+      console.error('GetClientsUseCase: Error:', error);
+      return [];
+    }
+  }
+}

--- a/front/central-next-js/src/features/clients/application/UpdateClientUseCase.ts
+++ b/front/central-next-js/src/features/clients/application/UpdateClientUseCase.ts
@@ -1,0 +1,15 @@
+import { ClientRepository } from '@/features/clients/ports/ClientRepository';
+import { UpdateClientDTO } from '@/features/clients/domain/Client';
+
+export class UpdateClientUseCase {
+  constructor(private repository: ClientRepository) {}
+
+  async execute(id: number, data: UpdateClientDTO): Promise<{ success: boolean; message?: string }> {
+    try {
+      return await this.repository.updateClient(id, data);
+    } catch (error) {
+      console.error('UpdateClientUseCase: Error:', error);
+      throw error;
+    }
+  }
+}

--- a/front/central-next-js/src/features/clients/domain/Client.ts
+++ b/front/central-next-js/src/features/clients/domain/Client.ts
@@ -1,0 +1,28 @@
+// Domain - Client Entity
+export interface Client {
+  id: number;
+  businessID: number;
+  name: string;
+  email: string;
+  phone: string;
+  dni?: string;
+  createdAt?: string;
+  updatedAt?: string;
+  deletedAt?: string | null;
+}
+
+export interface CreateClientDTO {
+  businessID: number;
+  name: string;
+  email: string;
+  phone: string;
+  dni?: string;
+}
+
+export interface UpdateClientDTO {
+  businessID?: number;
+  name?: string;
+  email?: string;
+  phone?: string;
+  dni?: string;
+}

--- a/front/central-next-js/src/features/clients/ports/ClientRepository.ts
+++ b/front/central-next-js/src/features/clients/ports/ClientRepository.ts
@@ -1,0 +1,9 @@
+import { Client, CreateClientDTO, UpdateClientDTO } from '@/features/clients/domain/Client';
+
+export interface ClientRepository {
+  getClients(): Promise<Client[]>;
+  getClientById(id: number): Promise<Client>;
+  createClient(data: CreateClientDTO): Promise<{ success: boolean; message?: string }>;
+  updateClient(id: number, data: UpdateClientDTO): Promise<{ success: boolean; message?: string }>;
+  deleteClient(id: number): Promise<{ success: boolean; message?: string }>;
+}

--- a/front/central-next-js/src/features/clients/ui/hooks/useClients.ts
+++ b/front/central-next-js/src/features/clients/ui/hooks/useClients.ts
@@ -1,0 +1,52 @@
+import { useState, useCallback, useMemo } from 'react';
+import { Client, CreateClientDTO, UpdateClientDTO } from '@/features/clients/domain/Client';
+import { ClientRepositoryHttp } from '@/features/clients/adapters/http/ClientRepositoryHttp';
+import { GetClientsUseCase } from '@/features/clients/application/GetClientsUseCase';
+import { CreateClientUseCase } from '@/features/clients/application/CreateClientUseCase';
+import { UpdateClientUseCase } from '@/features/clients/application/UpdateClientUseCase';
+import { DeleteClientUseCase } from '@/features/clients/application/DeleteClientUseCase';
+
+export const useClients = () => {
+  const [clients, setClients] = useState<Client[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const repository = useMemo(() => new ClientRepositoryHttp(), []);
+  const getUseCase = useMemo(() => new GetClientsUseCase(repository), [repository]);
+  const createUseCase = useMemo(() => new CreateClientUseCase(repository), [repository]);
+  const updateUseCase = useMemo(() => new UpdateClientUseCase(repository), [repository]);
+  const deleteUseCase = useMemo(() => new DeleteClientUseCase(repository), [repository]);
+
+  const loadClients = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const result = await getUseCase.execute();
+      setClients(result);
+    } catch (err: any) {
+      setError(err.message);
+    } finally {
+      setLoading(false);
+    }
+  }, [getUseCase]);
+
+  const createClient = useCallback(async (data: CreateClientDTO) => {
+    const result = await createUseCase.execute(data);
+    await loadClients();
+    return result;
+  }, [createUseCase, loadClients]);
+
+  const updateClient = useCallback(async (id: number, data: UpdateClientDTO) => {
+    const result = await updateUseCase.execute(id, data);
+    await loadClients();
+    return result;
+  }, [updateUseCase, loadClients]);
+
+  const deleteClient = useCallback(async (id: number) => {
+    const result = await deleteUseCase.execute(id);
+    await loadClients();
+    return result;
+  }, [deleteUseCase, loadClients]);
+
+  return { clients, loading, error, loadClients, createClient, updateClient, deleteClient };
+};

--- a/front/central-next-js/src/features/clients/ui/pages/ClientsPage.css
+++ b/front/central-next-js/src/features/clients/ui/pages/ClientsPage.css
@@ -1,0 +1,52 @@
+.clients-page {
+  min-height: 100vh;
+  background-color: #f8f9fa;
+  padding: 20px;
+}
+
+.page-header {
+  background: white;
+  padding: 20px;
+  border-radius: 12px;
+  box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+  margin-bottom: 30px;
+}
+
+.header-content h1 {
+  margin: 0 0 8px 0;
+  color: var(--foreground, #111827);
+  font-size: 2rem;
+  font-weight: 700;
+}
+
+.header-content p {
+  margin: 0;
+  color: var(--foreground, #6b7280);
+  font-size: 1rem;
+}
+
+.table-container {
+  background: white;
+  border-radius: 12px;
+  overflow: hidden;
+  box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+}
+
+.clients-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.clients-table th {
+  background: linear-gradient(135deg, var(--primary-color, #3b82f6) 0%, var(--secondary-color, #10b981) 100%);
+  color: white;
+  padding: 16px 12px;
+  text-align: left;
+  font-weight: 600;
+  font-size: 0.9rem;
+}
+
+.clients-table td {
+  padding: 16px 12px;
+  border-bottom: 1px solid #f3f4f6;
+}

--- a/front/central-next-js/src/features/clients/ui/pages/ClientsPage.tsx
+++ b/front/central-next-js/src/features/clients/ui/pages/ClientsPage.tsx
@@ -1,0 +1,63 @@
+'use client';
+
+import React, { useEffect } from 'react';
+import Layout from '@/shared/ui/components/Layout';
+import LoadingSpinner from '@/shared/ui/components/LoadingSpinner';
+import { useClients } from '../hooks/useClients';
+import './ClientsPage.css';
+
+export default function ClientsPage() {
+  const { clients, loading, error, loadClients } = useClients();
+
+  useEffect(() => {
+    loadClients();
+  }, [loadClients]);
+
+  return (
+    <Layout>
+      <div className="clients-page">
+        <div className="page-header">
+          <div className="header-content">
+            <h1>Administrar Clientes</h1>
+            <p>Listado de clientes registrados</p>
+          </div>
+        </div>
+
+        {loading && (
+          <div className="loading-container">
+            <LoadingSpinner />
+          </div>
+        )}
+
+        {error && (
+          <div className="error-container">
+            <p>{error}</p>
+          </div>
+        )}
+
+        {!loading && !error && (
+          <div className="table-container">
+            <table className="clients-table">
+              <thead>
+                <tr>
+                  <th>Nombre</th>
+                  <th>Email</th>
+                  <th>Teléfono</th>
+                </tr>
+              </thead>
+              <tbody>
+                {clients.map(client => (
+                  <tr key={client.id}>
+                    <td>{client.name}</td>
+                    <td>{client.email}</td>
+                    <td>{client.phone}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+    </Layout>
+  );
+}


### PR DESCRIPTION
## Summary
- add client domain types and repository interface
- implement HTTP service, repository, use cases, and hook for clients
- add clients page wired to API

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689aa0bdfc8c832bad537130a41f831e