### PR TITLE
refactor: use shared base components

### DIFF
--- a/front/central-next-js/src/features/tables/ui/components/DeleteConfirmModal.tsx
+++ b/front/central-next-js/src/features/tables/ui/components/DeleteConfirmModal.tsx
@@ -1,14 +1,15 @@
 'use client';
 
-import React from 'react';
+import React, { useState } from 'react';
 import { Table } from '@/features/tables/domain/Table';
+import ModalBase from '@/shared/ui/components/ModalBase/ModalBase';
+import ErrorMessage from '@/shared/ui/components/ErrorMessage/ErrorMessage';
 
 interface DeleteConfirmModalProps {
   isOpen: boolean;
   onClose: () => void;
   onConfirm: () => Promise<void>;
   table: Table | null;
-  loading: boolean;
 }
 
 const DeleteConfirmModal: React.FC<DeleteConfirmModalProps> = ({
@@ -16,77 +17,92 @@ const DeleteConfirmModal: React.FC<DeleteConfirmModalProps> = ({
   onClose,
   onConfirm,
   table,
-  loading
 }) => {
+  const [loading, setLoading] = useState(false);
+  const [apiError, setApiError] = useState<string | null>(null);
+
   if (!isOpen || !table) return null;
 
+  const handleConfirm = async () => {
+    setLoading(true);
+    setApiError(null);
+    try {
+      await onConfirm();
+      onClose();
+    } catch (error: any) {
+      const msg =
+        error?.response?.data?.message ||
+        error?.message ||
+        'Ocurrió un error al eliminar la mesa';
+      setApiError(msg);
+    } finally {
+      setLoading(false);
+    }
+  };
+
   return (
-    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
-      <div className="bg-white rounded-lg shadow-xl w-full max-w-md mx-4">
-        {/* Header con colores personalizados */}
-        <div 
-          className="px-6 py-4 rounded-t-lg text-white"
-          style={{
-            background: 'linear-gradient(135deg, #ef4444 0%, #dc2626 100%)'
-          }}
-        >
-          <h2 className="text-xl font-semibold">Confirmar Eliminación</h2>
-          <p className="text-sm opacity-90 mt-1">
-            Esta acción no se puede deshacer
-          </p>
-        </div>
+    <ModalBase
+      isOpen={isOpen}
+      onClose={onClose}
+      title="Confirmar Eliminación"
+      actions={
+        <>
+          <button
+            type="button"
+            className="btn-cancel"
+            onClick={onClose}
+            disabled={loading}
+          >
+            Cancelar
+          </button>
+          <button
+            type="button"
+            className="btn-submit"
+            style={{ background: 'linear-gradient(135deg, #ef4444 0%, #dc2626 100%)' }}
+            onClick={handleConfirm}
+            disabled={loading}
+          >
+            {loading ? 'Eliminando...' : 'Sí, Eliminar'}
+          </button>
+        </>
+      }
+      className="delete-confirm-modal"
+    >
+      {apiError && (
+        <ErrorMessage
+          message={apiError}
+          dismissible
+          onDismiss={() => setApiError(null)}
+          className="mb-4"
+        />
+      )}
 
-        <div className="p-6">
-          <div className="mb-6">
-            <div className="flex items-center justify-center w-16 h-16 mx-auto mb-4 bg-red-100 rounded-full">
-              <svg className="w-8 h-8 text-red-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4c-.77-.833-1.964-.833-2.732 0L3.732 16.5c-.77.833.192 2.5 1.732 2.5z" />
-              </svg>
-            </div>
-            
-            <h3 className="text-lg font-medium text-gray-900 text-center mb-2">
-              ¿Eliminar Mesa #{table.number}?
-            </h3>
-            
-            <p className="text-gray-600 text-center">
-              Estás a punto de eliminar la mesa número <strong>{table.number}</strong> con capacidad para <strong>{table.capacity}</strong> personas.
-            </p>
-            
-            <p className="text-red-600 text-sm text-center mt-2">
-              Esta acción no se puede deshacer y se eliminarán todas las reservas asociadas.
-            </p>
-          </div>
-
-          {/* Botones */}
-          <div className="flex gap-3">
-            <button
-              type="button"
-              onClick={onClose}
-              disabled={loading}
-                              className="flex-1 px-4 py-2 rounded-md text-gray-700 bg-gray-50 hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-gray-500 focus:ring-opacity-50 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-            >
-              Cancelar
-            </button>
-            <button
-              type="button"
-              onClick={onConfirm}
-              disabled={loading}
-              className="flex-1 px-4 py-2 bg-red-600 text-white rounded-md hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-opacity-50 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-            >
-              {loading ? (
-                <span className="flex items-center justify-center">
-                  <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-white mr-2"></div>
-                  Eliminando...
-                </span>
-              ) : (
-                'Sí, Eliminar'
-              )}
-            </button>
-          </div>
-        </div>
+      <div className="flex items-center justify-center w-16 h-16 mx-auto mb-4 bg-red-100 rounded-full">
+        <svg className="w-8 h-8 text-red-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4c-.77-.833-1.964-.833-2.732 0L3.732 16.5c-.77.833.192 2.5 1.732 2.5z"
+          />
+        </svg>
       </div>
-    </div>
+
+      <h3 className="text-lg font-medium text-center mb-2">
+        ¿Eliminar Mesa #{table.number}?
+      </h3>
+
+      <p className="text-center mb-2">
+        Estás a punto de eliminar la mesa número <strong>{table.number}</strong> con
+        capacidad para <strong>{table.capacity}</strong> personas.
+      </p>
+
+      <p className="text-red-600 text-sm text-center">
+        Esta acción no se puede deshacer y se eliminarán todas las reservas asociadas.
+      </p>
+    </ModalBase>
   );
 };
 
-export default DeleteConfirmModal; 
+export default DeleteConfirmModal;
+

--- a/front/central-next-js/src/features/tables/ui/pages/TablesPage.tsx
+++ b/front/central-next-js/src/features/tables/ui/pages/TablesPage.tsx
@@ -211,7 +211,6 @@ export default function TablesPage() {
           onClose={closeModals}
           onConfirm={handleDeleteTable}
           table={tableToDelete}
-          loading={loading}
         />
       </div>
     </Layout>


### PR DESCRIPTION
## Summary
- reuse ModalBase and ErrorMessage in table deletion flow
- wrap reservation creation in shared ModalBase with backend error handling
- migrate user management page to shared DataTable and ErrorMessage
- lazy-load user management modals and compute role/business lists during user fetch to speed up page load

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689ab2e1fc44832b8450ecabb9d11092