### PR TITLE
feat: return full business details

### DIFF
--- a/back/central-reserve/internal/infra/primary/http2/handlers/businesshandler/get-business-by-id.go
+++ b/back/central-reserve/internal/infra/primary/http2/handlers/businesshandler/get-business-by-id.go
@@ -5,9 +5,12 @@ import (
 	"strconv"
 
 	"central_reserve/internal/infra/primary/http2/handlers/businesshandler/mapper"
+	response "central_reserve/internal/infra/primary/http2/handlers/businesshandler/response"
 
 	"github.com/gin-gonic/gin"
 )
+
+var _ response.GetBusinessByIDResponse
 
 // GetBusinessByID godoc
 // @Summary Obtener negocio por ID
@@ -17,7 +20,7 @@ import (
 // @Produce json
 // @Security     BearerAuth
 // @Param id path int true "ID del negocio"
-// @Success      201          {object}  map[string]interface{} "Negocio obtenido exitosamente"
+// @Success      200          {object}  response.GetBusinessByIDResponse "Negocio obtenido exitosamente"
 // @Failure      400          {object}  map[string]interface{} "Solicitud inválida"
 // @Failure      401          {object}  map[string]interface{} "Token de acceso requerido"
 // @Failure      500          {object}  map[string]interface{} "Error interno del servidor"
@@ -44,6 +47,6 @@ func (h *BusinessHandler) GetBusinessByIDHandler(c *gin.Context) {
 	}
 
 	// Construir respuesta exitosa
-	response := mapper.BuildGetBusinessResponseFromDTO(business, "Negocio obtenido exitosamente")
+	response := mapper.BuildGetBusinessByIDResponseFromDTO(business, "Negocio obtenido exitosamente")
 	c.JSON(http.StatusOK, response)
 }

--- a/back/central-reserve/internal/infra/primary/http2/handlers/businesshandler/mapper/business-response-mapper.go
+++ b/back/central-reserve/internal/infra/primary/http2/handlers/businesshandler/mapper/business-response-mapper.go
@@ -85,6 +85,38 @@ func BusinessDTOToResponse(businessDTO dtos.BusinessResponse) response.BusinessR
 	}
 }
 
+// BusinessDTOToDetailResponse convierte un DTO BusinessResponse a response.BusinessDetailResponse
+func BusinessDTOToDetailResponse(businessDTO dtos.BusinessResponse) response.BusinessDetailResponse {
+	return response.BusinessDetailResponse{
+		ID:   businessDTO.ID,
+		Name: businessDTO.Name,
+		Code: businessDTO.Code,
+		BusinessType: response.BusinessTypeDetailResponse{
+			ID:          businessDTO.BusinessType.ID,
+			Name:        businessDTO.BusinessType.Name,
+			Code:        businessDTO.BusinessType.Code,
+			Description: businessDTO.BusinessType.Description,
+			Icon:        businessDTO.BusinessType.Icon,
+			IsActive:    businessDTO.BusinessType.IsActive,
+			CreatedAt:   businessDTO.BusinessType.CreatedAt,
+			UpdatedAt:   businessDTO.BusinessType.UpdatedAt,
+		},
+		Timezone:           businessDTO.Timezone,
+		Address:            businessDTO.Address,
+		Description:        businessDTO.Description,
+		LogoURL:            businessDTO.LogoURL,
+		PrimaryColor:       businessDTO.PrimaryColor,
+		SecondaryColor:     businessDTO.SecondaryColor,
+		CustomDomain:       businessDTO.CustomDomain,
+		IsActive:           businessDTO.IsActive,
+		EnableDelivery:     businessDTO.EnableDelivery,
+		EnablePickup:       businessDTO.EnablePickup,
+		EnableReservations: businessDTO.EnableReservations,
+		CreatedAt:          businessDTO.CreatedAt,
+		UpdatedAt:          businessDTO.UpdatedAt,
+	}
+}
+
 // BusinessesToResponse convierte un slice de entidades Business a slice de BusinessResponse
 func BusinessesToResponse(businesses []entities.Business) []response.BusinessResponse {
 	responses := make([]response.BusinessResponse, len(businesses))
@@ -180,6 +212,15 @@ func BuildGetBusinessResponseFromDTO(businessDTO *dtos.BusinessResponse, message
 		Success: true,
 		Message: message,
 		Data:    BusinessDTOToResponse(*businessDTO),
+	}
+}
+
+// BuildGetBusinessByIDResponseFromDTO construye la respuesta completa para obtener un negocio con toda su información desde un DTO
+func BuildGetBusinessByIDResponseFromDTO(businessDTO *dtos.BusinessResponse, message string) response.GetBusinessByIDResponse {
+	return response.GetBusinessByIDResponse{
+		Success: true,
+		Message: message,
+		Data:    BusinessDTOToDetailResponse(*businessDTO),
 	}
 }
 

--- a/back/central-reserve/internal/infra/primary/http2/handlers/businesshandler/response/business-detail-response.go
+++ b/back/central-reserve/internal/infra/primary/http2/handlers/businesshandler/response/business-detail-response.go
@@ -1,0 +1,43 @@
+package response
+
+import "time"
+
+// BusinessTypeDetailResponse represents a business type in detail responses
+type BusinessTypeDetailResponse struct {
+	ID          uint      `json:"id"`
+	Name        string    `json:"name"`
+	Code        string    `json:"code"`
+	Description string    `json:"description"`
+	Icon        string    `json:"icon"`
+	IsActive    bool      `json:"is_active"`
+	CreatedAt   time.Time `json:"created_at"`
+	UpdatedAt   time.Time `json:"updated_at"`
+}
+
+// BusinessDetailResponse represents full business information for editing
+type BusinessDetailResponse struct {
+	ID                 uint                       `json:"id"`
+	Name               string                     `json:"name"`
+	Code               string                     `json:"code"`
+	BusinessType       BusinessTypeDetailResponse `json:"business_type"`
+	Timezone           string                     `json:"timezone"`
+	Address            string                     `json:"address"`
+	Description        string                     `json:"description"`
+	LogoURL            string                     `json:"logo_url"`
+	PrimaryColor       string                     `json:"primary_color"`
+	SecondaryColor     string                     `json:"secondary_color"`
+	CustomDomain       string                     `json:"custom_domain"`
+	IsActive           bool                       `json:"is_active"`
+	EnableDelivery     bool                       `json:"enable_delivery"`
+	EnablePickup       bool                       `json:"enable_pickup"`
+	EnableReservations bool                       `json:"enable_reservations"`
+	CreatedAt          time.Time                  `json:"created_at"`
+	UpdatedAt          time.Time                  `json:"updated_at"`
+}
+
+// GetBusinessByIDResponse represents the response for getting a business by ID with full information
+type GetBusinessByIDResponse struct {
+	Success bool                   `json:"success"`
+	Message string                 `json:"message"`
+	Data    BusinessDetailResponse `json:"data"`
+}


### PR DESCRIPTION
## Summary
- add detailed business response structs
- map dto to detailed business response and builder
- update handler to return full business data for editing

## Testing
- `go test ./...` (no output, interrupted)


------
https://chatgpt.com/codex/tasks/task_e_689aca9cbb48832bb01118deafd4fd26