### PR TITLE
Expose reservation status and allow status updates

### DIFF
--- a/back/central-reserve/internal/app/usecasereserve/constructor.go
+++ b/back/central-reserve/internal/app/usecasereserve/constructor.go
@@ -15,7 +15,7 @@ type IUseCaseReserve interface {
 	GetReserves(ctx context.Context, statusID *uint, clientID *uint, tableID *uint, startDate *time.Time, endDate *time.Time) ([]dtos.ReserveDetailDTO, error)
 	GetReserveByID(ctx context.Context, id uint) (*dtos.ReserveDetailDTO, error)
 	CancelReservation(ctx context.Context, id uint, reason string) (string, error)
-	UpdateReservation(ctx context.Context, id uint, tableID *uint, startAt *time.Time, endAt *time.Time, numberOfGuests *int) (string, error)
+	UpdateReservation(ctx context.Context, params dtos.UpdateReservationDTO) (string, error)
 }
 
 type ReserveUseCase struct {

--- a/back/central-reserve/internal/app/usecasereserve/update-reservation.go
+++ b/back/central-reserve/internal/app/usecasereserve/update-reservation.go
@@ -1,12 +1,12 @@
 package usecasereserve
 
 import (
+	"central_reserve/internal/domain/dtos"
 	"context"
-	"time"
 )
 
-func (u *ReserveUseCase) UpdateReservation(ctx context.Context, id uint, tableID *uint, startAt *time.Time, endAt *time.Time, numberOfGuests *int) (string, error) {
-	response, err := u.repository.UpdateReservation(ctx, id, tableID, startAt, endAt, numberOfGuests)
+func (u *ReserveUseCase) UpdateReservation(ctx context.Context, params dtos.UpdateReservationDTO) (string, error) {
+	response, err := u.repository.UpdateReservation(ctx, params)
 	if err != nil {
 		return "", err
 	}

--- a/back/central-reserve/internal/domain/dtos/reservation.go
+++ b/back/central-reserve/internal/domain/dtos/reservation.go
@@ -1,7 +1,6 @@
 package dtos
 
 import (
-	"central_reserve/internal/domain/entities"
 	"time"
 )
 
@@ -41,9 +40,6 @@ type ReserveDetailDTO struct {
 	UsuarioID     *uint
 	UsuarioNombre *string
 	UsuarioEmail  *string
-
-	// Historial de Estados
-	StatusHistory []entities.ReservationStatusHistory `gorm:"-"`
 }
 
 // DBReservationStatusHistory representa el modelo de base de datos para crear historial
@@ -51,4 +47,14 @@ type DBReservationStatusHistory struct {
 	ReservationID   uint
 	StatusID        uint
 	ChangedByUserID *uint
+}
+
+// UpdateReservationDTO encapsula los campos opcionales para actualizar una reserva
+type UpdateReservationDTO struct {
+	ID             uint
+	TableID        *uint
+	StartAt        *time.Time
+	EndAt          *time.Time
+	NumberOfGuests *int
+	StatusID       *uint
 }

--- a/back/central-reserve/internal/domain/ports/repositories.go
+++ b/back/central-reserve/internal/domain/ports/repositories.go
@@ -45,7 +45,7 @@ type IReservationRepository interface {
 	GetReserves(ctx context.Context, statusID *uint, clientID *uint, tableID *uint, startDate *time.Time, endDate *time.Time) ([]dtos.ReserveDetailDTO, error)
 	GetReserveByID(ctx context.Context, id uint) (*dtos.ReserveDetailDTO, error)
 	CancelReservation(ctx context.Context, id uint, reason string) (string, error)
-	UpdateReservation(ctx context.Context, id uint, tableID *uint, startAt *time.Time, endAt *time.Time, numberOfGuests *int) (string, error)
+	UpdateReservation(ctx context.Context, params dtos.UpdateReservationDTO) (string, error)
 	CreateReservationStatusHistory(ctx context.Context, history entities.ReservationStatusHistory) error
 	GetClientByEmailAndBusiness(ctx context.Context, email string, businessID uint) (*entities.Client, error)
 	CreateClient(ctx context.Context, client entities.Client) (string, error)

--- a/back/central-reserve/internal/infra/primary/http2/handlers/reservehandler/mapper/reserve-mapper.go
+++ b/back/central-reserve/internal/infra/primary/http2/handlers/reservehandler/mapper/reserve-mapper.go
@@ -48,34 +48,7 @@ func MapToReserveDetail(dto dtos.ReserveDetailDTO) response.ReserveDetail {
 		UsuarioID:        dto.UsuarioID,
 		UsuarioNombre:    dto.UsuarioNombre,
 		UsuarioEmail:     dto.UsuarioEmail,
-		StatusHistory:    MapStatusHistoryList(dto.StatusHistory),
 	}
-}
-
-// MapStatusHistory convierte un entities.ReservationStatusHistory a response.StatusHistoryResponse
-func MapStatusHistory(history entities.ReservationStatusHistory) response.StatusHistoryResponse {
-	return response.StatusHistoryResponse{
-		ID:              history.ID,
-		StatusID:        history.StatusID,
-		StatusCode:      history.StatusCode,
-		StatusName:      history.StatusName,
-		ChangedAt:       history.CreatedAt,
-		ChangedByUserID: history.ChangedByUserID,
-		ChangedByUser:   history.ChangedByUser,
-	}
-}
-
-// MapStatusHistoryList convierte un slice de entities.ReservationStatusHistory a slice de response.StatusHistoryResponse
-func MapStatusHistoryList(historyList []entities.ReservationStatusHistory) []response.StatusHistoryResponse {
-	if historyList == nil {
-		return nil
-	}
-
-	responseList := make([]response.StatusHistoryResponse, len(historyList))
-	for i, history := range historyList {
-		responseList[i] = MapStatusHistory(history)
-	}
-	return responseList
 }
 
 // MapToReserveDetailList convierte un slice de dtos.ReserveDetailDTO a slice de response.ReserveDetail

--- a/back/central-reserve/internal/infra/primary/http2/handlers/reservehandler/request/update-reserve-request.go
+++ b/back/central-reserve/internal/infra/primary/http2/handlers/reservehandler/request/update-reserve-request.go
@@ -9,4 +9,5 @@ type UpdateReservation struct {
 	StartAt        *time.Time `json:"start_at,omitempty"`
 	EndAt          *time.Time `json:"end_at,omitempty"`
 	NumberOfGuests *int       `json:"number_of_guests,omitempty"`
+	StatusID       *uint      `json:"status_id,omitempty"`
 }

--- a/back/central-reserve/internal/infra/primary/http2/handlers/reservehandler/response/reserve-response.go
+++ b/back/central-reserve/internal/infra/primary/http2/handlers/reservehandler/response/reserve-response.go
@@ -4,16 +4,6 @@ import (
 	"time"
 )
 
-type StatusHistory struct {
-	ID              uint      `json:"id"`
-	StatusID        uint      `json:"status_id"`
-	StatusCode      string    `json:"status_code"`
-	StatusName      string    `json:"status_name"`
-	ChangedAt       time.Time `json:"changed_at"`
-	ChangedByUserID *uint     `json:"changed_by_user_id"`
-	ChangedByUser   *string   `json:"changed_by_user"`
-}
-
 type ReserveDetail struct {
 	// Reserva
 	ReservaID          uint      `json:"reserva_id"`
@@ -49,17 +39,4 @@ type ReserveDetail struct {
 	UsuarioID     *uint   `json:"usuario_id"`
 	UsuarioNombre *string `json:"usuario_nombre"`
 	UsuarioEmail  *string `json:"usuario_email"`
-
-	// Historial de Estados - usando el struct del dominio con tags JSON
-	StatusHistory []StatusHistoryResponse `json:"status_history"`
-}
-
-type StatusHistoryResponse struct {
-	ID              uint      `json:"id"`
-	StatusID        uint      `json:"status_id"`
-	StatusCode      string    `json:"status_code"`
-	StatusName      string    `json:"status_name"`
-	ChangedAt       time.Time `json:"changed_at"`
-	ChangedByUserID *uint     `json:"changed_by_user_id"`
-	ChangedByUser   *string   `json:"changed_by_user"`
 }

--- a/back/central-reserve/internal/infra/primary/http2/handlers/reservehandler/update-reservation.go
+++ b/back/central-reserve/internal/infra/primary/http2/handlers/reservehandler/update-reservation.go
@@ -1,6 +1,7 @@
 package reservehandler
 
 import (
+	"central_reserve/internal/domain/dtos"
 	"central_reserve/internal/infra/primary/http2/handlers/reservehandler/request"
 	"net/http"
 	"strconv"
@@ -51,7 +52,16 @@ func (h *ReserveHandler) UpdateReservationHandler(c *gin.Context) {
 	}
 
 	// 3. Caso de uso ─────────────────────────────────────────
-	response, err := h.usecase.UpdateReservation(ctx, uint(reservationID), updateReq.TableID, updateReq.StartAt, updateReq.EndAt, updateReq.NumberOfGuests)
+	params := dtos.UpdateReservationDTO{
+		ID:             uint(reservationID),
+		TableID:        updateReq.TableID,
+		StartAt:        updateReq.StartAt,
+		EndAt:          updateReq.EndAt,
+		NumberOfGuests: updateReq.NumberOfGuests,
+		StatusID:       updateReq.StatusID,
+	}
+
+	response, err := h.usecase.UpdateReservation(ctx, params)
 	if err != nil {
 		h.logger.Error().Err(err).Msg("error interno al actualizar reserva")
 		c.JSON(http.StatusInternalServerError, gin.H{


### PR DESCRIPTION
## Summary
- preload reservation status in queries so GET endpoints return status info
- remove `status_history` from reservation responses
- allow updating reservation status via PUT and record history
- pass reservation update parameters via dedicated DTO

## Testing
- `go test ./...` *(fails: command hung and was interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_689d491e7b3c832bb5a6ae5ebd2503ae