### PR TITLE
Include reservation status ID in responses

### DIFF
--- a/back/central-reserve/internal/domain/dtos/reservation.go
+++ b/back/central-reserve/internal/domain/dtos/reservation.go
@@ -15,6 +15,7 @@ type ReserveDetailDTO struct {
 	ReservaActualizada time.Time
 
 	// Estado
+	EstadoID     uint
 	EstadoCodigo string
 	EstadoNombre string
 

--- a/back/central-reserve/internal/infra/primary/http2/docs/docs.go
+++ b/back/central-reserve/internal/infra/primary/http2/docs/docs.go
@@ -1830,8 +1830,7 @@ const docTemplate = `{
                     "200": {
                         "description": "Lista de reservas obtenida exitosamente",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": true
+                            "$ref": "#/definitions/response.ReserveListSuccessResponse"
                         }
                     },
                     "400": {
@@ -1889,8 +1888,7 @@ const docTemplate = `{
                     "201": {
                         "description": "Reserva creada exitosamente",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": true
+                            "$ref": "#/definitions/response.ReserveSuccessResponse"
                         }
                     },
                     "400": {
@@ -1948,8 +1946,7 @@ const docTemplate = `{
                     "200": {
                         "description": "Reserva obtenida exitosamente",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": true
+                            "$ref": "#/definitions/response.ReserveSuccessResponse"
                         }
                     },
                     "400": {
@@ -4518,6 +4515,55 @@ const docTemplate = `{
                         "$ref": "#/definitions/internal_infra_primary_http2_handlers_authhandler_response.RoleInfo"
                     }
                 }
+            }
+        },
+        "internal_infra_primary_http2_handlers_reservehandler_response.ReserveDetail": {
+            "type": "object",
+            "properties": {
+                "reserva_id": {"type": "integer"},
+                "start_at": {"type": "string"},
+                "end_at": {"type": "string"},
+                "number_of_guests": {"type": "integer"},
+                "reserva_creada": {"type": "string"},
+                "reserva_actualizada": {"type": "string"},
+                "estado_id": {"type": "integer"},
+                "estado_codigo": {"type": "string"},
+                "estado_nombre": {"type": "string"},
+                "cliente_id": {"type": "integer"},
+                "cliente_nombre": {"type": "string"},
+                "cliente_email": {"type": "string"},
+                "cliente_telefono": {"type": "string"},
+                "cliente_dni": {"type": "string"},
+                "mesa_id": {"type": "integer"},
+                "mesa_numero": {"type": "integer"},
+                "mesa_capacidad": {"type": "integer"},
+                "negocio_id": {"type": "integer"},
+                "negocio_nombre": {"type": "string"},
+                "negocio_codigo": {"type": "string"},
+                "negocio_direccion": {"type": "string"},
+                "usuario_id": {"type": "integer"},
+                "usuario_nombre": {"type": "string"},
+                "usuario_email": {"type": "string"}
+            }
+        },
+        "response.ReserveSuccessResponse": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "$ref": "#/definitions/internal_infra_primary_http2_handlers_reservehandler_response.ReserveDetail"
+                },
+                "success": {"type": "boolean"}
+            }
+        },
+        "response.ReserveListSuccessResponse": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "type": "array",
+                    "items": {"$ref": "#/definitions/internal_infra_primary_http2_handlers_reservehandler_response.ReserveDetail"}
+                },
+                "success": {"type": "boolean"},
+                "total": {"type": "integer"}
             }
         },
         "response.UserRolesPermissionsSuccessResponse": {

--- a/back/central-reserve/internal/infra/primary/http2/docs/swagger.json
+++ b/back/central-reserve/internal/infra/primary/http2/docs/swagger.json
@@ -1824,8 +1824,7 @@
                     "200": {
                         "description": "Lista de reservas obtenida exitosamente",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": true
+                            "$ref": "#/definitions/response.ReserveListSuccessResponse"
                         }
                     },
                     "400": {
@@ -1883,8 +1882,7 @@
                     "201": {
                         "description": "Reserva creada exitosamente",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": true
+                            "$ref": "#/definitions/response.ReserveSuccessResponse"
                         }
                     },
                     "400": {
@@ -1942,8 +1940,7 @@
                     "200": {
                         "description": "Reserva obtenida exitosamente",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": true
+                            "$ref": "#/definitions/response.ReserveSuccessResponse"
                         }
                     },
                     "400": {
@@ -4512,6 +4509,55 @@
                         "$ref": "#/definitions/internal_infra_primary_http2_handlers_authhandler_response.RoleInfo"
                     }
                 }
+            }
+        },
+        "internal_infra_primary_http2_handlers_reservehandler_response.ReserveDetail": {
+            "type": "object",
+            "properties": {
+                "reserva_id": {"type": "integer"},
+                "start_at": {"type": "string"},
+                "end_at": {"type": "string"},
+                "number_of_guests": {"type": "integer"},
+                "reserva_creada": {"type": "string"},
+                "reserva_actualizada": {"type": "string"},
+                "estado_id": {"type": "integer"},
+                "estado_codigo": {"type": "string"},
+                "estado_nombre": {"type": "string"},
+                "cliente_id": {"type": "integer"},
+                "cliente_nombre": {"type": "string"},
+                "cliente_email": {"type": "string"},
+                "cliente_telefono": {"type": "string"},
+                "cliente_dni": {"type": "string"},
+                "mesa_id": {"type": "integer"},
+                "mesa_numero": {"type": "integer"},
+                "mesa_capacidad": {"type": "integer"},
+                "negocio_id": {"type": "integer"},
+                "negocio_nombre": {"type": "string"},
+                "negocio_codigo": {"type": "string"},
+                "negocio_direccion": {"type": "string"},
+                "usuario_id": {"type": "integer"},
+                "usuario_nombre": {"type": "string"},
+                "usuario_email": {"type": "string"}
+            }
+        },
+        "response.ReserveSuccessResponse": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "$ref": "#/definitions/internal_infra_primary_http2_handlers_reservehandler_response.ReserveDetail"
+                },
+                "success": {"type": "boolean"}
+            }
+        },
+        "response.ReserveListSuccessResponse": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "type": "array",
+                    "items": {"$ref": "#/definitions/internal_infra_primary_http2_handlers_reservehandler_response.ReserveDetail"}
+                },
+                "success": {"type": "boolean"},
+                "total": {"type": "integer"}
             }
         },
         "response.UserRolesPermissionsSuccessResponse": {

--- a/back/central-reserve/internal/infra/primary/http2/docs/swagger.yaml
+++ b/back/central-reserve/internal/infra/primary/http2/docs/swagger.yaml
@@ -697,6 +697,75 @@ definitions:
       success:
         type: boolean
     type: object
+  internal_infra_primary_http2_handlers_reservehandler_response.ReserveDetail:
+    properties:
+      reserva_id:
+        type: integer
+      start_at:
+        type: string
+      end_at:
+        type: string
+      number_of_guests:
+        type: integer
+      reserva_creada:
+        type: string
+      reserva_actualizada:
+        type: string
+      estado_id:
+        type: integer
+      estado_codigo:
+        type: string
+      estado_nombre:
+        type: string
+      cliente_id:
+        type: integer
+      cliente_nombre:
+        type: string
+      cliente_email:
+        type: string
+      cliente_telefono:
+        type: string
+      cliente_dni:
+        type: string
+      mesa_id:
+        type: integer
+      mesa_numero:
+        type: integer
+      mesa_capacidad:
+        type: integer
+      negocio_id:
+        type: integer
+      negocio_nombre:
+        type: string
+      negocio_codigo:
+        type: string
+      negocio_direccion:
+        type: string
+      usuario_id:
+        type: integer
+      usuario_nombre:
+        type: string
+      usuario_email:
+        type: string
+    type: object
+  response.ReserveSuccessResponse:
+    properties:
+      data:
+        $ref: '#/definitions/internal_infra_primary_http2_handlers_reservehandler_response.ReserveDetail'
+      success:
+        type: boolean
+    type: object
+  response.ReserveListSuccessResponse:
+    properties:
+      data:
+        items:
+          $ref: '#/definitions/internal_infra_primary_http2_handlers_reservehandler_response.ReserveDetail'
+        type: array
+      success:
+        type: boolean
+      total:
+        type: integer
+    type: object
 host: localhost:8080
 info:
   contact:
@@ -1897,8 +1966,7 @@ paths:
         "200":
           description: Lista de reservas obtenida exitosamente
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/response.ReserveListSuccessResponse'
         "400":
           description: Parámetros inválidos
           schema:
@@ -1937,8 +2005,7 @@ paths:
         "201":
           description: Reserva creada exitosamente
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/response.ReserveSuccessResponse'
         "400":
           description: Solicitud inválida
           schema:
@@ -1977,8 +2044,7 @@ paths:
         "200":
           description: Reserva obtenida exitosamente
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/response.ReserveSuccessResponse'
         "400":
           description: ID inválido
           schema:

--- a/back/central-reserve/internal/infra/primary/http2/handlers/reservehandler/create-reserve.go
+++ b/back/central-reserve/internal/infra/primary/http2/handlers/reservehandler/create-reserve.go
@@ -16,7 +16,7 @@ import (
 // @Produce      json
 // @Security     BearerAuth
 // @Param        reservation  body      request.Reservation  true  "Datos de la reserva"
-// @Success      201          {object}  map[string]interface{} "Reserva creada exitosamente"
+// @Success      201          {object}  response.ReserveSuccessResponse "Reserva creada exitosamente"
 // @Failure      400          {object}  map[string]interface{} "Solicitud inválida"
 // @Failure      401          {object}  map[string]interface{} "Token de acceso requerido"
 // @Failure      500          {object}  map[string]interface{} "Error interno del servidor"

--- a/back/central-reserve/internal/infra/primary/http2/handlers/reservehandler/get-reserve-by-id.go
+++ b/back/central-reserve/internal/infra/primary/http2/handlers/reservehandler/get-reserve-by-id.go
@@ -15,7 +15,7 @@ import (
 // @Produce      json
 // @Security     BearerAuth
 // @Param        id   path    int  true  "ID de la reserva"
-// @Success      200  {object}  map[string]interface{} "Reserva obtenida exitosamente"
+// @Success      200  {object}  response.ReserveSuccessResponse "Reserva obtenida exitosamente"
 // @Failure      400  {object}  map[string]interface{} "ID inválido"
 // @Failure      401  {object}  map[string]interface{} "Token de acceso requerido"
 // @Failure      404  {object}  map[string]interface{} "Reserva no encontrada"

--- a/back/central-reserve/internal/infra/primary/http2/handlers/reservehandler/get-reserves.go
+++ b/back/central-reserve/internal/infra/primary/http2/handlers/reservehandler/get-reserves.go
@@ -20,7 +20,7 @@ import (
 // @Param        table_id    query    int     false  "ID de la mesa"
 // @Param        start_date  query    string  false  "Fecha de inicio (formato RFC3339: 2024-01-01T00:00:00Z)"
 // @Param        end_date    query    string  false  "Fecha de fin (formato RFC3339: 2024-12-31T23:59:59Z)"
-// @Success      200  {object}  map[string]interface{} "Lista de reservas obtenida exitosamente"
+// @Success      200  {object}  response.ReserveListSuccessResponse "Lista de reservas obtenida exitosamente"
 // @Failure      400  {object}  map[string]interface{} "Parámetros inválidos"
 // @Failure      401  {object}  map[string]interface{} "Token de acceso requerido"
 // @Failure      500  {object}  map[string]interface{} "Error interno del servidor"

--- a/back/central-reserve/internal/infra/primary/http2/handlers/reservehandler/mapper/reserve-mapper.go
+++ b/back/central-reserve/internal/infra/primary/http2/handlers/reservehandler/mapper/reserve-mapper.go
@@ -26,6 +26,7 @@ func MapToReserveDetail(dto dtos.ReserveDetailDTO) response.ReserveDetail {
 		NumberOfGuests:     dto.NumberOfGuests,
 		ReservaCreada:      dto.ReservaCreada,
 		ReservaActualizada: dto.ReservaActualizada,
+		EstadoID:           dto.EstadoID,
 		EstadoCodigo:       dto.EstadoCodigo,
 		EstadoNombre:       dto.EstadoNombre,
 		ClienteID:          dto.ClienteID,

--- a/back/central-reserve/internal/infra/primary/http2/handlers/reservehandler/response/reserve-response.go
+++ b/back/central-reserve/internal/infra/primary/http2/handlers/reservehandler/response/reserve-response.go
@@ -14,6 +14,7 @@ type ReserveDetail struct {
 	ReservaActualizada time.Time `json:"reserva_actualizada"`
 
 	// Estado
+	EstadoID     uint   `json:"estado_id"`
 	EstadoCodigo string `json:"estado_codigo"`
 	EstadoNombre string `json:"estado_nombre"`
 
@@ -39,4 +40,17 @@ type ReserveDetail struct {
 	UsuarioID     *uint   `json:"usuario_id"`
 	UsuarioNombre *string `json:"usuario_nombre"`
 	UsuarioEmail  *string `json:"usuario_email"`
+}
+
+// ReserveSuccessResponse representa una respuesta exitosa con una reserva
+type ReserveSuccessResponse struct {
+	Success bool          `json:"success"`
+	Data    ReserveDetail `json:"data"`
+}
+
+// ReserveListSuccessResponse representa una respuesta exitosa con una lista de reservas
+type ReserveListSuccessResponse struct {
+	Success bool            `json:"success"`
+	Data    []ReserveDetail `json:"data"`
+	Total   int             `json:"total"`
 }

--- a/back/central-reserve/internal/infra/secundary/repository/reservation_repository.go
+++ b/back/central-reserve/internal/infra/secundary/repository/reservation_repository.go
@@ -78,6 +78,7 @@ func (r *Repository) GetReserves(ctx context.Context, statusID *uint, clientID *
 			NumberOfGuests:     reservation.NumberOfGuests,
 			ReservaCreada:      reservation.CreatedAt,
 			ReservaActualizada: reservation.UpdatedAt,
+			EstadoID:           reservation.StatusID,
 		}
 
 		// Manejar relaciones de forma segura
@@ -154,6 +155,7 @@ func (r *Repository) GetReserveByID(ctx context.Context, id uint) (*dtos.Reserve
 		NumberOfGuests:     gormReservation.NumberOfGuests,
 		ReservaCreada:      gormReservation.CreatedAt,
 		ReservaActualizada: gormReservation.UpdatedAt,
+		EstadoID:           gormReservation.StatusID,
 		EstadoCodigo:       gormReservation.Status.Code,
 		EstadoNombre:       gormReservation.Status.Name,
 		ClienteID:          gormReservation.Client.ID,


### PR DESCRIPTION
## Summary
- expose reservation status ID in ReserveDetail DTO and API response
- map status ID through handlers and repository
- document reservation status fields and responses in Swagger

## Testing
- `go test ./...` *(fails: module downloads blocked in environment)*

------
https://chatgpt.com/codex/tasks/task_e_689d50d3bbdc832ba0742ea6209f15e5