### PR TITLE
Fix month indicator color in calendar

### DIFF
--- a/mobile/rupu/lib/presentation/views/reserve/calendar_view.dart
+++ b/mobile/rupu/lib/presentation/views/reserve/calendar_view.dart
@@ -881,4 +881,20 @@ class _ReserveCalendarDataSource extends CalendarDataSource {
   _ReserveCalendarDataSource(List<Appointment> appts) {
     appointments = appts;
   }
+
+  @override
+  Color getColor(int index) {
+    final Appointment appt = appointments![index] as Appointment;
+    final Color? color = appt.color;
+
+    // When the appointment color is not defined, the indicator falls back
+    // to the default calendar color (usually blue).  This overrides the
+    // behavior so that the month view indicator uses the same palette as
+    // the custom appointment builder.
+    if (color == null || color == Colors.transparent) {
+      return ApptPalette.infoBg;
+    }
+
+    return color;
+  }
 }


### PR DESCRIPTION
## Summary
- Ensure month-view appointment indicators use same palette as the appointment builder

## Testing
- `dart format mobile/rupu/lib/presentation/views/reserve/calendar_view.dart` *(fails: command not found)*
- `cd mobile/rupu && flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689d58a69d08832aa053714de960bb5f