### PR TITLE
feat: add reservation status listing API

### DIFF
--- a/back/central-reserve/internal/app/usecasereserve/constructor.go
+++ b/back/central-reserve/internal/app/usecasereserve/constructor.go
@@ -16,6 +16,7 @@ type IUseCaseReserve interface {
 	GetReserveByID(ctx context.Context, id uint) (*dtos.ReserveDetailDTO, error)
 	CancelReservation(ctx context.Context, id uint, reason string) (string, error)
 	UpdateReservation(ctx context.Context, params dtos.UpdateReservationDTO) (string, error)
+	GetReservationStatuses(ctx context.Context) ([]dtos.ReservationStatusDTO, error)
 }
 
 type ReserveUseCase struct {

--- a/back/central-reserve/internal/app/usecasereserve/get-reservation-statuses.go
+++ b/back/central-reserve/internal/app/usecasereserve/get-reservation-statuses.go
@@ -1,0 +1,29 @@
+package usecasereserve
+
+import (
+	"central_reserve/internal/domain/dtos"
+	"context"
+)
+
+// GetReservationStatuses obtiene todos los estados de reserva
+func (u *ReserveUseCase) GetReservationStatuses(ctx context.Context) ([]dtos.ReservationStatusDTO, error) {
+	u.log.Info().Msg("Iniciando caso de uso: obtener estados de reserva")
+
+	statuses, err := u.repository.GetReservationStatuses(ctx)
+	if err != nil {
+		u.log.Error().Err(err).Msg("Error al obtener estados de reserva desde el repositorio")
+		return nil, err
+	}
+
+	dtoStatuses := make([]dtos.ReservationStatusDTO, len(statuses))
+	for i, status := range statuses {
+		dtoStatuses[i] = dtos.ReservationStatusDTO{
+			ID:   status.ID,
+			Code: status.Code,
+			Name: status.Name,
+		}
+	}
+
+	u.log.Info().Int("count", len(dtoStatuses)).Msg("Estados de reserva obtenidos exitosamente")
+	return dtoStatuses, nil
+}

--- a/back/central-reserve/internal/domain/dtos/reservation_status.go
+++ b/back/central-reserve/internal/domain/dtos/reservation_status.go
@@ -1,0 +1,8 @@
+package dtos
+
+// ReservationStatusDTO representa un estado de reserva
+type ReservationStatusDTO struct {
+	ID   uint   `json:"id"`
+	Code string `json:"code"`
+	Name string `json:"name"`
+}

--- a/back/central-reserve/internal/domain/ports/repositories.go
+++ b/back/central-reserve/internal/domain/ports/repositories.go
@@ -49,6 +49,7 @@ type IReservationRepository interface {
 	CreateReservationStatusHistory(ctx context.Context, history entities.ReservationStatusHistory) error
 	GetClientByEmailAndBusiness(ctx context.Context, email string, businessID uint) (*entities.Client, error)
 	CreateClient(ctx context.Context, client entities.Client) (string, error)
+	GetReservationStatuses(ctx context.Context) ([]entities.ReservationStatus, error)
 }
 
 // IAuthRepository define las operaciones de autenticación

--- a/back/central-reserve/internal/infra/primary/http2/docs/swagger.json
+++ b/back/central-reserve/internal/infra/primary/http2/docs/swagger.json
@@ -2121,6 +2121,38 @@
                 }
             }
         },
+        "/reserves/status": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Obtiene los estados de las reservas",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Reservas"
+                ],
+                "summary": "Lista los estados de reserva",
+                "responses": {
+                    "200": {
+                        "description": "Estados de reserva obtenidos correctamente",
+                        "schema": {
+                            "$ref": "#/definitions/response.ReservationStatusListSuccessResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Error interno del servidor",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    }
+                }
+            }
+        },
         "/roles": {
             "get": {
                 "security": [
@@ -4558,6 +4590,24 @@
                 },
                 "success": {"type": "boolean"},
                 "total": {"type": "integer"}
+            }
+        },
+        "response.ReservationStatus": {
+            "type": "object",
+            "properties": {
+                "id": {"type": "integer"},
+                "code": {"type": "string"},
+                "name": {"type": "string"}
+            }
+        },
+        "response.ReservationStatusListSuccessResponse": {
+            "type": "object",
+            "properties": {
+                "success": {"type": "boolean"},
+                "data": {
+                    "type": "array",
+                    "items": {"$ref": "#/definitions/response.ReservationStatus"}
+                }
             }
         },
         "response.UserRolesPermissionsSuccessResponse": {

--- a/back/central-reserve/internal/infra/primary/http2/docs/swagger.yaml
+++ b/back/central-reserve/internal/infra/primary/http2/docs/swagger.yaml
@@ -766,6 +766,24 @@ definitions:
       total:
         type: integer
     type: object
+  response.ReservationStatus:
+    properties:
+      id:
+        type: integer
+      code:
+        type: string
+      name:
+        type: string
+    type: object
+  response.ReservationStatusListSuccessResponse:
+    properties:
+      success:
+        type: boolean
+      data:
+        type: array
+        items:
+          $ref: '#/definitions/response.ReservationStatus'
+    type: object
 host: localhost:8080
 info:
   contact:
@@ -2167,6 +2185,26 @@ paths:
       security:
       - BearerAuth: []
       summary: Cancela una reserva
+      tags:
+      - Reservas
+  /reserves/status:
+    get:
+      description: Obtiene los estados de las reservas
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Estados de reserva obtenidos correctamente
+          schema:
+            $ref: '#/definitions/response.ReservationStatusListSuccessResponse'
+        "500":
+          description: Error interno del servidor
+          schema:
+            type: object
+            additionalProperties: true
+      security:
+      - BearerAuth: []
+      summary: Lista los estados de reserva
       tags:
       - Reservas
   /roles:

--- a/back/central-reserve/internal/infra/primary/http2/handlers/reservehandler/constructor.go
+++ b/back/central-reserve/internal/infra/primary/http2/handlers/reservehandler/constructor.go
@@ -14,6 +14,7 @@ type IReserveHandler interface {
 	GetReserveByIDHandler(c *gin.Context)
 	CancelReservationHandler(c *gin.Context)
 	UpdateReservationHandler(c *gin.Context)
+	GetReservationStatusesHandler(c *gin.Context)
 }
 
 type ReserveHandler struct {

--- a/back/central-reserve/internal/infra/primary/http2/handlers/reservehandler/get-reservation-statuses.go
+++ b/back/central-reserve/internal/infra/primary/http2/handlers/reservehandler/get-reservation-statuses.go
@@ -1,0 +1,39 @@
+package reservehandler
+
+import (
+	"central_reserve/internal/infra/primary/http2/handlers/reservehandler/mapper"
+	"central_reserve/internal/infra/primary/http2/handlers/reservehandler/response"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+)
+
+// GetReservationStatusesHandler obtiene los estados de reserva
+// @Summary      Lista los estados de reserva
+// @Description  Obtiene todos los estados de reserva disponibles
+// @Tags         Reservas
+// @Produce      json
+// @Security     BearerAuth
+// @Success      200  {object}  response.ReservationStatusListSuccessResponse "Estados de reserva obtenidos correctamente"
+// @Failure      500  {object}  map[string]interface{} "Error interno del servidor"
+// @Router       /reserves/status [get]
+func (h *ReserveHandler) GetReservationStatusesHandler(c *gin.Context) {
+	ctx := c.Request.Context()
+
+	statuses, err := h.usecase.GetReservationStatuses(ctx)
+	if err != nil {
+		h.logger.Error().Err(err).Msg("error al obtener estados de reserva")
+		c.JSON(http.StatusInternalServerError, gin.H{
+			"success": false,
+			"error":   "internal_error",
+			"message": "No se pudieron obtener los estados de reserva",
+		})
+		return
+	}
+
+	statusList := mapper.MapToReservationStatusList(statuses)
+	c.JSON(http.StatusOK, response.ReservationStatusListSuccessResponse{
+		Success: true,
+		Data:    statusList,
+	})
+}

--- a/back/central-reserve/internal/infra/primary/http2/handlers/reservehandler/mapper/reserve-mapper.go
+++ b/back/central-reserve/internal/infra/primary/http2/handlers/reservehandler/mapper/reserve-mapper.go
@@ -64,3 +64,24 @@ func MapToReserveDetailList(dtoList []dtos.ReserveDetailDTO) []response.ReserveD
 	}
 	return responseList
 }
+
+// MapToReservationStatus convierte un dtos.ReservationStatusDTO a response.ReservationStatus
+func MapToReservationStatus(dto dtos.ReservationStatusDTO) response.ReservationStatus {
+	return response.ReservationStatus{
+		ID:   dto.ID,
+		Code: dto.Code,
+		Name: dto.Name,
+	}
+}
+
+// MapToReservationStatusList convierte un slice de dtos.ReservationStatusDTO a slice de response.ReservationStatus
+func MapToReservationStatusList(dtoList []dtos.ReservationStatusDTO) []response.ReservationStatus {
+	if dtoList == nil {
+		return nil
+	}
+	responseList := make([]response.ReservationStatus, len(dtoList))
+	for i, dto := range dtoList {
+		responseList[i] = MapToReservationStatus(dto)
+	}
+	return responseList
+}

--- a/back/central-reserve/internal/infra/primary/http2/handlers/reservehandler/response/reservation-status-response.go
+++ b/back/central-reserve/internal/infra/primary/http2/handlers/reservehandler/response/reservation-status-response.go
@@ -1,0 +1,14 @@
+package response
+
+// ReservationStatus representa un estado de reserva
+type ReservationStatus struct {
+	ID   uint   `json:"id"`
+	Code string `json:"code"`
+	Name string `json:"name"`
+}
+
+// ReservationStatusListSuccessResponse representa una respuesta exitosa con lista de estados
+type ReservationStatusListSuccessResponse struct {
+	Success bool                `json:"success"`
+	Data    []ReservationStatus `json:"data"`
+}

--- a/back/central-reserve/internal/infra/primary/http2/handlers/reservehandler/router.go
+++ b/back/central-reserve/internal/infra/primary/http2/handlers/reservehandler/router.go
@@ -15,6 +15,7 @@ func RegisterRoutes(v1Group *gin.RouterGroup, handler IReserveHandler, jwtServic
 
 	reserves.GET("", auth.JWT(), handler.GetReservesHandler)
 	reserves.GET("/:id", auth.JWT(), handler.GetReserveByIDHandler)
+	reserves.GET("/status", auth.JWT(), handler.GetReservationStatusesHandler)
 	reserves.PUT("/:id", auth.JWT(), handler.UpdateReservationHandler)
 	reserves.PATCH("/:id/cancel", auth.JWT(), handler.CancelReservationHandler)
 

--- a/back/central-reserve/internal/infra/secundary/repository/mapper/reservation_mapper.go
+++ b/back/central-reserve/internal/infra/secundary/repository/mapper/reservation_mapper.go
@@ -3,6 +3,7 @@ package mapper
 import (
 	"central_reserve/internal/domain/entities"
 	"dbpostgres/app/infra/models"
+	"time"
 )
 
 // ReservationToEntity convierte models.Reservation a entities.Reservation
@@ -71,6 +72,32 @@ func ReservationStatusHistorySliceToEntitySlice(histories []models.ReservationSt
 	result := make([]entities.ReservationStatusHistory, len(histories))
 	for i, history := range histories {
 		result[i] = ReservationStatusHistoryToEntity(history)
+	}
+	return result
+}
+
+// ReservationStatusToEntity convierte models.ReservationStatus a entities.ReservationStatus
+func ReservationStatusToEntity(status models.ReservationStatus) entities.ReservationStatus {
+	var deletedAt *time.Time
+	if status.DeletedAt.Valid {
+		t := status.DeletedAt.Time
+		deletedAt = &t
+	}
+	return entities.ReservationStatus{
+		ID:        status.ID,
+		Code:      status.Code,
+		Name:      status.Name,
+		CreatedAt: status.CreatedAt,
+		UpdatedAt: status.UpdatedAt,
+		DeletedAt: deletedAt,
+	}
+}
+
+// ReservationStatusSliceToEntitySlice convierte []models.ReservationStatus a []entities.ReservationStatus
+func ReservationStatusSliceToEntitySlice(statuses []models.ReservationStatus) []entities.ReservationStatus {
+	result := make([]entities.ReservationStatus, len(statuses))
+	for i, status := range statuses {
+		result[i] = ReservationStatusToEntity(status)
 	}
 	return result
 }

--- a/back/central-reserve/internal/infra/secundary/repository/reservation_repository.go
+++ b/back/central-reserve/internal/infra/secundary/repository/reservation_repository.go
@@ -207,6 +207,16 @@ func (r *Repository) CancelReservation(ctx context.Context, id uint, reason stri
 	return fmt.Sprintf("Reserva cancelada con ID: %d", id), nil
 }
 
+// GetReservationStatuses obtiene todos los estados de reserva
+func (r *Repository) GetReservationStatuses(ctx context.Context) ([]entities.ReservationStatus, error) {
+	var gormStatuses []models.ReservationStatus
+	if err := r.database.Conn(ctx).Find(&gormStatuses).Error; err != nil {
+		r.logger.Error().Err(err).Msg("Error al obtener estados de reserva")
+		return nil, err
+	}
+	return mapper.ReservationStatusSliceToEntitySlice(gormStatuses), nil
+}
+
 // UpdateReservation actualiza una reserva
 func (r *Repository) UpdateReservation(ctx context.Context, params dtos.UpdateReservationDTO) (string, error) {
 	updates := make(map[string]interface{})


### PR DESCRIPTION
## Summary
- expose reservation status listing endpoint
- document reservation status endpoint in swagger

## Testing
- `go test ./...`
- `make docs` *(fails: swag: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689d5d3fbb84832b8c165523937e1984