### PR TITLE
feat: add docker support for central-next frontend

### DIFF
--- a/front/central-next-js/Dockerfile
+++ b/front/central-next-js/Dockerfile
@@ -1,0 +1,30 @@
+# Multi-stage build for Next.js (ARM64)
+FROM --platform=linux/arm64 node:18-alpine AS builder
+
+# Set working directory
+WORKDIR /app
+
+# Install dependencies
+COPY package*.json ./
+RUN npm ci
+
+# Copy source code
+COPY . .
+
+# Build the application
+RUN npm run build
+
+# Production image
+FROM --platform=linux/arm64 node:18-alpine AS runner
+WORKDIR /app
+ENV NODE_ENV=production
+
+# Copy built assets and production dependencies
+COPY --from=builder /app/package*.json ./
+COPY --from=builder /app/.next ./.next
+COPY --from=builder /app/public ./public
+COPY --from=builder /app/node_modules ./node_modules
+
+# Expose port and run
+EXPOSE 3000
+CMD ["npm", "start"]

--- a/front/central-next-js/scripts/deploy.sh
+++ b/front/central-next-js/scripts/deploy.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+# Deployment script for central-next-js frontend
+set -e
+
+IMAGE_NAME="central-next-frontend"
+ECR_REPO="public.ecr.aws/d3a6d4r1/cam/reserve"
+TAG="frontend-latest"
+DOCKERFILE_PATH="Dockerfile"
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+echo -e "${GREEN}🚀 Starting deployment of central-next-js frontend${NC}"
+
+# Verify project files
+if [ ! -f "package.json" ]; then
+  echo -e "${RED}❌ package.json not found. Run from project root.${NC}"
+  exit 1
+fi
+
+# Verify Docker
+if ! docker info > /dev/null 2>&1; then
+  echo -e "${RED}❌ Docker is not running${NC}"
+  exit 1
+fi
+
+# Verify AWS CLI
+if ! aws sts get-caller-identity > /dev/null 2>&1; then
+  echo -e "${RED}❌ AWS CLI not configured${NC}"
+  exit 1
+fi
+
+echo -e "${YELLOW}⏬ Pulling existing image for cache (if available)...${NC}"
+docker pull ${ECR_REPO}:${TAG} || true
+
+echo -e "${YELLOW}🔨 Building image for ARM64...${NC}"
+docker buildx build \
+  --platform linux/arm64 \
+  --cache-from ${ECR_REPO}:${TAG} \
+  -f ${DOCKERFILE_PATH} \
+  -t ${IMAGE_NAME}:${TAG} \
+  --load \
+  .
+
+echo -e "${YELLOW}🏷️ Tagging image...${NC}"
+docker tag ${IMAGE_NAME}:${TAG} ${ECR_REPO}:${TAG}
+
+echo -e "${YELLOW}🔐 Logging into public ECR...${NC}"
+aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws
+
+echo -e "${YELLOW}⬆️ Pushing image to ECR...${NC}"
+docker push ${ECR_REPO}:${TAG}
+
+echo -e "${GREEN}✅ Image pushed to ${ECR_REPO}:${TAG}${NC}"


### PR DESCRIPTION
## Summary
- add ARM64 Dockerfile for central-next-js
- add deploy script that pulls existing image and pushes `frontend-latest`

## Testing
- `bash -n front/central-next-js/scripts/deploy.sh`
- `cd front/central-next-js && npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_689e34433ac0832b89ac1672d23d01ac