### PR TITLE
Fix auth loading state

### DIFF
--- a/front/central-next-js/src/shared/hooks/useServerAuth.ts
+++ b/front/central-next-js/src/shared/hooks/useServerAuth.ts
@@ -49,7 +49,7 @@ export const useServerAuth = () => {
     isAuthenticated: false,
     user: null,
     permissions: null,
-    loading: false,
+    loading: true,
     error: null
   });
 
@@ -142,6 +142,9 @@ export const useServerAuth = () => {
   const checkAuth = useCallback(async () => {
     console.log('🔍 [useServerAuth] Verificando autenticación...');
     try {
+      // Marcar como cargando antes de iniciar la verificación
+      setState(prev => ({ ...prev, loading: true }));
+
       const result = await checkAuthAction();
       console.log('✅ [useServerAuth] Verificación completada:', result);
       

--- a/front/central-next-js/src/shared/hooks/useServerAuth.ts
+++ b/front/central-next-js/src/shared/hooks/useServerAuth.ts
@@ -87,6 +87,9 @@ export const useServerAuth = () => {
         
         console.log('🔍 [useServerAuth] Ahora debería cargar permisos automáticamente...');
 
+        // Cargar permisos inmediatamente después del login exitoso
+        await loadUserRolesPermissions();
+
         return result;
       } else {
         console.log('❌ [useServerAuth] Login falló:', result.message);
@@ -107,7 +110,7 @@ export const useServerAuth = () => {
       }));
       throw error;
     }
-  }, [state.loading]);
+  }, [state.loading, loadUserRolesPermissions]);
 
   // Logout usando Server Action
   const logout = useCallback(async () => {
@@ -313,7 +316,9 @@ export const useServerAuth = () => {
       console.log('🔄 [useServerAuth] Ya se está verificando autenticación, saltando...');
       return;
     }
-    
+
+    authCheckRef.current = true;
+
     try {
       console.log('🔍 [useServerAuth] Llamando a checkAuth...');
       const authResult = await checkAuth();


### PR DESCRIPTION
## Summary
- prevent premature redirects by starting useServerAuth in a loading state
- ensure checkAuth sets loading flag before verifying cookies

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68a1613687c0832b9d66c020e58d49ea