### PR TITLE
feat: add check-in action

### DIFF
--- a/mobile/rupu/lib/presentation/views/reserve/reserve_detail_view.dart
+++ b/mobile/rupu/lib/presentation/views/reserve/reserve_detail_view.dart
@@ -192,8 +192,15 @@ class ReserveDetailView extends GetView<ReserveDetailController> {
 
                                   if (ctx.mounted) Navigator.of(ctx).pop();
 
-                                  if (!context.mounted) return;
                                   if (ok) {
+                                    await reserveCtrl.cargarReservasHoy(
+                                      silent: true,
+                                    );
+                                    await reserveCtrl.cargarReservasTodas(
+                                      silent: true,
+                                    );
+                                    await controller.cargarReserva(r.reservaId);
+                                    if (!context.mounted) return;
                                     await _showResultSheet(
                                       context,
                                       icon: Icons.check_circle_outline,
@@ -203,6 +210,7 @@ class ReserveDetailView extends GetView<ReserveDetailController> {
                                           'La reserva ha sido confirmada.',
                                     );
                                   } else {
+                                    if (!context.mounted) return;
                                     await _showResultSheet(
                                       context,
                                       icon: Icons.error_outline,

--- a/mobile/rupu/lib/presentation/views/reserve/reserves_controller.dart
+++ b/mobile/rupu/lib/presentation/views/reserve/reserves_controller.dart
@@ -84,6 +84,41 @@ class ReserveController extends GetxController {
     }
   }
 
+  // ================= Check-in =================
+  Future<bool> checkInReserva({required int id}) async {
+    try {
+      isSaving.value = true;
+
+      Reserve? r;
+      try {
+        r = reservasHoy.firstWhere((e) => e.reservaId == id);
+      } catch (_) {}
+      if (r == null) {
+        try {
+          r = reservasTodas.firstWhere((e) => e.reservaId == id);
+        } catch (_) {}
+      }
+      r ??= await repository.obtenerReserva(id: id);
+
+      final updated = await repository.actualizarReserva(
+        id: id,
+        startAt: r.startAt,
+        endAt: r.endAt,
+        numberOfGuests: r.numberOfGuests,
+        statusId: 2,
+        tableId: r.mesaId,
+      );
+
+      actualizarLocal(updated);
+      return true;
+    } catch (e) {
+      debugPrint('CTRL checkInReserva error: $e');
+      return false;
+    } finally {
+      isSaving.value = false;
+    }
+  }
+
   // ================= Home (solo HOY) =================
   Future<void> cargarReservasHoy({bool silent = false}) async {
     if (!silent) isLoading.value = true;


### PR DESCRIPTION
## Summary
- add controller method to update reservations to confirmed status
- implement check-in confirmation flow in detail view
- enable check-in directly from calendar appointments

## Testing
- `flutter analyze` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a5c68e16d0832a8c5eb6c52f1f36b1