### PR TITLE
feat(mobile): add clients view and navigation

### DIFF
--- a/mobile/rupu/lib/config/routers/app_bindings.dart
+++ b/mobile/rupu/lib/config/routers/app_bindings.dart
@@ -58,3 +58,11 @@ class ReserveUpdateBinding {
     }
   }
 }
+
+class ClientsBinding {
+  static void register() {
+    if (!Get.isRegistered<ClientsController>()) {
+      Get.put(ClientsController());
+    }
+  }
+}

--- a/mobile/rupu/lib/config/routers/app_router.dart
+++ b/mobile/rupu/lib/config/routers/app_router.dart
@@ -63,6 +63,15 @@ final appRouter = GoRouter(
           },
         ),
         GoRoute(
+          path: '/home/:page/clients',
+          name: ClientsView.name,
+          builder: (context, state) {
+            ClientsBinding.register();
+            final page = int.parse(state.pathParameters['page']!);
+            return ClientsView(pageIndex: page);
+          },
+        ),
+        GoRoute(
           path: '/home/:page/reserve/new',
           name: 'reserve_new',
           builder: (context, state) {

--- a/mobile/rupu/lib/domain/datasource/client_datasource.dart
+++ b/mobile/rupu/lib/domain/datasource/client_datasource.dart
@@ -1,0 +1,5 @@
+import '../entities/client.dart';
+
+abstract class ClientDatasource {
+  Future<List<Client>> obtenerClientesConReservaHoy();
+}

--- a/mobile/rupu/lib/domain/entities/client.dart
+++ b/mobile/rupu/lib/domain/entities/client.dart
@@ -1,0 +1,15 @@
+class Client {
+  final int id;
+  final String nombre;
+  final String email;
+  final String telefono;
+  final String dni;
+
+  Client({
+    required this.id,
+    required this.nombre,
+    required this.email,
+    required this.telefono,
+    required this.dni,
+  });
+}

--- a/mobile/rupu/lib/domain/infrastructure/datasources/clients_datasource_impl.dart
+++ b/mobile/rupu/lib/domain/infrastructure/datasources/clients_datasource_impl.dart
@@ -1,0 +1,39 @@
+import '../../datasource/client_datasource.dart';
+import '../../entities/client.dart';
+import 'reservas_datasource_impl.dart';
+
+class ClientsDatasourceImpl extends ClientDatasource {
+  final ReservasDatasourceImpl reservasDatasource;
+  ClientsDatasourceImpl({ReservasDatasourceImpl? datasource})
+      : reservasDatasource = datasource ?? ReservasDatasourceImpl();
+
+  @override
+  Future<List<Client>> obtenerClientesConReservaHoy() async {
+    final reservas = await reservasDatasource.obtenerReservas();
+    final now = DateTime.now();
+    final Map<int, Client> unicos = {};
+    for (final r in reservas) {
+      final dt = _parseDate(r.startAt);
+      if (dt != null && _sameDay(dt, now)) {
+        unicos[r.clienteId] = Client(
+          id: r.clienteId,
+          nombre: r.clienteNombre,
+          email: r.clienteEmail,
+          telefono: r.clienteTelefono,
+          dni: r.clienteDni,
+        );
+      }
+    }
+    return unicos.values.toList();
+  }
+
+  DateTime? _parseDate(dynamic raw) {
+    if (raw == null) return null;
+    if (raw is DateTime) return raw.toLocal();
+    if (raw is String) return DateTime.tryParse(raw)?.toLocal();
+    return null;
+  }
+
+  bool _sameDay(DateTime a, DateTime b) =>
+      a.year == b.year && a.month == b.month && a.day == b.day;
+}

--- a/mobile/rupu/lib/domain/infrastructure/repositories/client_repository_impl.dart
+++ b/mobile/rupu/lib/domain/infrastructure/repositories/client_repository_impl.dart
@@ -1,0 +1,13 @@
+import '../../datasource/client_datasource.dart';
+import '../../entities/client.dart';
+import '../../repositories/client_repository.dart';
+
+class ClientRepositoryImpl extends ClientRepository {
+  final ClientDatasource datasource;
+  ClientRepositoryImpl(this.datasource);
+
+  @override
+  Future<List<Client>> obtenerClientesConReservaHoy() {
+    return datasource.obtenerClientesConReservaHoy();
+  }
+}

--- a/mobile/rupu/lib/domain/repositories/client_repository.dart
+++ b/mobile/rupu/lib/domain/repositories/client_repository.dart
@@ -1,0 +1,5 @@
+import '../entities/client.dart';
+
+abstract class ClientRepository {
+  Future<List<Client>> obtenerClientesConReservaHoy();
+}

--- a/mobile/rupu/lib/presentation/views/clients/clients_controller.dart
+++ b/mobile/rupu/lib/presentation/views/clients/clients_controller.dart
@@ -1,0 +1,34 @@
+import 'package:get/get.dart';
+import 'package:rupu/domain/entities/client.dart';
+import 'package:rupu/domain/repositories/client_repository.dart';
+import 'package:rupu/domain/infrastructure/repositories/client_repository_impl.dart';
+import 'package:rupu/domain/infrastructure/datasources/clients_datasource_impl.dart';
+
+class ClientsController extends GetxController {
+  final ClientRepository repository;
+  ClientsController()
+      : repository = ClientRepositoryImpl(ClientsDatasourceImpl());
+
+  final isLoading = false.obs;
+  final errorMessage = RxnString();
+  final clientes = <Client>[].obs;
+
+  @override
+  void onReady() {
+    super.onReady();
+    cargarClientes();
+  }
+
+  Future<void> cargarClientes({bool silent = false}) async {
+    if (!silent) isLoading.value = true;
+    errorMessage.value = null;
+    try {
+      final items = await repository.obtenerClientesConReservaHoy();
+      clientes.assignAll(items);
+    } catch (e) {
+      errorMessage.value = 'No se pudieron cargar los clientes';
+    } finally {
+      if (!silent) isLoading.value = false;
+    }
+  }
+}

--- a/mobile/rupu/lib/presentation/views/clients/clients_view.dart
+++ b/mobile/rupu/lib/presentation/views/clients/clients_view.dart
@@ -1,0 +1,40 @@
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+import 'clients_controller.dart';
+
+class ClientsView extends GetView<ClientsController> {
+  const ClientsView({super.key, required this.pageIndex});
+  static const name = 'clients';
+  final int pageIndex;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Clientes')),
+      body: Obx(() {
+        if (controller.isLoading.value) {
+          return const Center(child: CircularProgressIndicator());
+        }
+        final error = controller.errorMessage.value;
+        if (error != null) {
+          return Center(child: Text(error));
+        }
+        if (controller.clientes.isEmpty) {
+          return const Center(child: Text('Sin clientes con reserva'));
+        }
+        return ListView.separated(
+          itemCount: controller.clientes.length,
+          separatorBuilder: (_, __) => const Divider(height: 1),
+          itemBuilder: (context, index) {
+            final c = controller.clientes[index];
+            return ListTile(
+              title: Text(c.nombre),
+              subtitle: Text(c.email),
+              trailing: Text(c.telefono),
+            );
+          },
+        );
+      }),
+    );
+  }
+}

--- a/mobile/rupu/lib/presentation/views/reserve/reserve_view.dart
+++ b/mobile/rupu/lib/presentation/views/reserve/reserve_view.dart
@@ -277,7 +277,10 @@ class ReserveView extends GetView<ReserveController> {
                   pathParameters: {'page': '$pageIndex'},
                 ),
                 onCheckIn: () {}, // TODO: tu flujo de check-in
-                onClients: () {}, // TODO: navegación a clientes
+                onClients: () => context.pushNamed(
+                  ClientsView.name,
+                  pathParameters: {'page': '$pageIndex'},
+                ),
               ),
               const SizedBox(height: 16),
 

--- a/mobile/rupu/lib/presentation/views/views.dart
+++ b/mobile/rupu/lib/presentation/views/views.dart
@@ -18,6 +18,9 @@ export 'package:rupu/presentation/views/reserve/reserve_detail_view.dart';
 export 'package:rupu/presentation/views/reserve/reserve_update_controller.dart';
 export 'package:rupu/presentation/views/reserve/update_reserve_view.dart';
 
+export 'package:rupu/presentation/views/clients/clients_controller.dart';
+export 'package:rupu/presentation/views/clients/clients_view.dart';
+
 export 'package:rupu/presentation/views/profile/perfil_view.dart';
 
 export 'package:rupu/presentation/views/home/home_view.dart';


### PR DESCRIPTION
## Summary
- add Client entity, datasource, and repository to gather clients with reservations
- create Clients view/controller with binding and routing
- hook QuickActions button to navigate to Clients list

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bcf6eb5cd8832aa8c3dc078774d260