### PR TITLE
refactor reserve module widgets

### DIFF
--- a/mobile/rupu/lib/presentation/views/reserve/views/create_reserve_view.dart
+++ b/mobile/rupu/lib/presentation/views/reserve/views/create_reserve_view.dart
@@ -5,6 +5,7 @@ import 'package:intl/intl.dart';
 
 import 'package:rupu/presentation/views/profile/perfil_controller.dart';
 import 'package:rupu/presentation/views/reserve/controllers/reserves_controller.dart';
+import '../widgets.dart';
 
 class CreateReserveView extends StatefulWidget {
   const CreateReserveView({super.key});
@@ -287,26 +288,26 @@ class _CreateReserveViewState extends State<CreateReserveView> {
                     ],
                   ),
                   const SizedBox(height: 12),
-                  _ConfirmRow(
+                  ConfirmRow(
                     icon: Icons.person_outline,
                     label: 'Cliente',
                     value: name,
                   ),
                   const SizedBox(height: 6),
-                  _ConfirmRow(
+                  ConfirmRow(
                     icon: Icons.schedule,
                     label: 'Horario',
                     value: timeRange,
                   ),
                   const SizedBox(height: 6),
-                  _ConfirmRow(
+                  ConfirmRow(
                     icon: Icons.group_outlined,
                     label: 'Personas',
                     value: '$guests',
                   ),
                   if ((email ?? '').isNotEmpty) ...[
                     const SizedBox(height: 6),
-                    _ConfirmRow(
+                    ConfirmRow(
                       icon: Icons.email_outlined,
                       label: 'Email',
                       value: email!,
@@ -314,7 +315,7 @@ class _CreateReserveViewState extends State<CreateReserveView> {
                   ],
                   if ((phone ?? '').isNotEmpty) ...[
                     const SizedBox(height: 6),
-                    _ConfirmRow(
+                    ConfirmRow(
                       icon: Icons.phone_outlined,
                       label: 'Teléfono',
                       value: phone!,
@@ -322,7 +323,7 @@ class _CreateReserveViewState extends State<CreateReserveView> {
                   ],
                   if ((dni ?? '').isNotEmpty) ...[
                     const SizedBox(height: 6),
-                    _ConfirmRow(
+                    ConfirmRow(
                       icon: Icons.badge_outlined,
                       label: 'Documento',
                       value: dni!,
@@ -550,7 +551,7 @@ class _CreateReserveViewState extends State<CreateReserveView> {
                     Row(
                       children: [
                         Expanded(
-                          child: _DateTile(
+                          child: DateTile(
                             label: 'Inicio',
                             value: DateFormat(
                               'EEE d MMM, HH:mm',
@@ -562,7 +563,7 @@ class _CreateReserveViewState extends State<CreateReserveView> {
                         ),
                         const SizedBox(width: 8),
                         Expanded(
-                          child: _DateTile(
+                          child: DateTile(
                             label: 'Fin',
                             value: DateFormat(
                               'EEE d MMM, HH:mm',
@@ -629,94 +630,3 @@ class _CreateReserveViewState extends State<CreateReserveView> {
   }
 }
 
-class _DateTile extends StatelessWidget {
-  const _DateTile({
-    required this.label,
-    required this.value,
-    required this.icon,
-    required this.onTap,
-  });
-
-  final String label;
-  final String value;
-  final IconData icon;
-  final VoidCallback onTap;
-
-  @override
-  Widget build(BuildContext context) {
-    final cs = Theme.of(context).colorScheme;
-    final tt = Theme.of(context).textTheme;
-    return InkWell(
-      borderRadius: BorderRadius.circular(12),
-      onTap: onTap,
-      child: Container(
-        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 12),
-        decoration: BoxDecoration(
-          color: cs.surface,
-          borderRadius: BorderRadius.circular(12),
-          border: Border.all(color: cs.outlineVariant),
-        ),
-        child: Row(
-          children: [
-            Icon(icon, color: cs.primary),
-            const SizedBox(width: 10),
-            Expanded(
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Text(
-                    label,
-                    style: tt.labelMedium!.copyWith(color: cs.onSurfaceVariant),
-                  ),
-                  const SizedBox(height: 4),
-                  Text(
-                    value,
-                    style: tt.titleSmall!.copyWith(fontWeight: FontWeight.w700),
-                  ),
-                ],
-              ),
-            ),
-            const Icon(Icons.edit_calendar_outlined),
-          ],
-        ),
-      ),
-    );
-  }
-}
-
-class _ConfirmRow extends StatelessWidget {
-  const _ConfirmRow({
-    required this.icon,
-    required this.label,
-    required this.value,
-  });
-  final IconData icon;
-  final String label;
-  final String value;
-
-  @override
-  Widget build(BuildContext context) {
-    final cs = Theme.of(context).colorScheme;
-    final tt = Theme.of(context).textTheme;
-    return Row(
-      children: [
-        Icon(icon, size: 18, color: cs.onSurfaceVariant),
-        const SizedBox(width: 8),
-        Text(
-          label,
-          style: tt.labelMedium!.copyWith(color: cs.onSurfaceVariant),
-        ),
-        // const Spacer(),
-        SizedBox(width: 60),
-        Flexible(
-          child: Text(
-            value,
-            textAlign: TextAlign.end,
-            overflow: TextOverflow.ellipsis,
-            style: tt.bodyMedium!.copyWith(fontWeight: FontWeight.w700),
-          ),
-        ),
-      ],
-    );
-  }
-}

--- a/mobile/rupu/lib/presentation/views/reserve/views/reserve_detail_view.dart
+++ b/mobile/rupu/lib/presentation/views/reserve/views/reserve_detail_view.dart
@@ -11,6 +11,9 @@ import 'update_reserve_view.dart';
 import 'package:url_launcher/url_launcher.dart';
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 import '../controllers/reserves_controller.dart';
+import 'package:rupu/config/helpers/calendar_helper.dart';
+import 'package:rupu/presentation/widgets/widgets.dart';
+import '../widgets.dart';
 
 class ReserveDetailView extends GetView<ReserveDetailController> {
   const ReserveDetailView({super.key, required this.pageIndex});
@@ -299,10 +302,9 @@ class ReserveDetailView extends GetView<ReserveDetailController> {
           key: const PageStorageKey('reserve-detail'),
           padding: const EdgeInsets.fromLTRB(16, 16, 16, 24),
           children: [
-            _HeaderCard(
+            HeaderCard(
               name: name.isEmpty ? 'Cliente' : name,
               email: (r.clienteEmail).trim(),
-              statusText: r.estadoNombre,
               bannerUrl: businessLogoUrl,
               initial: initial,
             ),
@@ -333,13 +335,13 @@ class ReserveDetailView extends GetView<ReserveDetailController> {
                               const SizedBox(height: 6),
                               Row(
                                 children: [
-                                  _TimeChip(
+                                  TimeChip(
                                     icon: Icons.schedule,
                                     label:
                                         '${dfTime.format(start)} – ${dfTime.format(end)}',
                                   ),
                                   const SizedBox(width: 8),
-                                  _TimeChip(
+                                  TimeChip(
                                     icon: Icons.timelapse,
                                     label: durationLabel,
                                   ),
@@ -348,7 +350,10 @@ class ReserveDetailView extends GetView<ReserveDetailController> {
                             ],
                           ),
                         ),
-                        StatusPill(text: _normalizeStatus(r.estadoNombre)),
+                        SoftStatusPill(
+                          text: _normalizeStatus(r.estadoNombre),
+                          tone: _toneForStatus(r.estadoNombre),
+                        ),
                       ],
                     ),
                     const SizedBox(height: 16),
@@ -359,24 +364,24 @@ class ReserveDetailView extends GetView<ReserveDetailController> {
                       runSpacing: 10,
                       spacing: 16,
                       children: [
-                        _InfoTile(
+                        InfoTile(
                           icon: Icons.group_outlined,
                           label: 'Personas',
                           value: '${r.numberOfGuests}',
                         ),
                         if ((r.mesaNumero ?? '').toString().isNotEmpty)
-                          _InfoTile(
+                          InfoTile(
                             icon: Icons.table_bar_outlined,
                             label: 'Mesa',
                             value: '${r.mesaNumero}',
                           ),
                         if ((r.negocioNombre).trim().isNotEmpty)
-                          _InfoTile(
+                          InfoTile(
                             icon: Icons.store_mall_directory_outlined,
                             label: 'Negocio',
                             value: r.negocioNombre,
                           ),
-                        _InfoTile(
+                        InfoTile(
                           icon: Icons.confirmation_number_outlined,
                           label: 'Reserva',
                           value: '#${r.reservaId}',
@@ -406,22 +411,22 @@ class ReserveDetailView extends GetView<ReserveDetailController> {
                 child: Column(
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
-                    _SectionTitle('Contacto del cliente'),
+                    const SectionTitle('Contacto del cliente'),
                     const SizedBox(height: 10),
                     if (r.clienteTelefono.toString().trim().isNotEmpty)
-                      _ContactRow(
+                      ContactRow(
                         icon: Icons.phone_outlined,
                         label: 'Teléfono',
                         value: r.clienteTelefono.toString(),
                       ),
                     if ((r.clienteEmail).trim().isNotEmpty)
-                      _ContactRow(
+                      ContactRow(
                         icon: Icons.email_outlined,
                         label: 'Email',
                         value: r.clienteEmail,
                       ),
                     if ((r.clienteDni).toString().trim().isNotEmpty)
-                      _ContactRow(
+                      ContactRow(
                         icon: Icons.badge_outlined,
                         label: 'Documento',
                         value: r.clienteDni.toString(),
@@ -517,7 +522,7 @@ class ReserveDetailView extends GetView<ReserveDetailController> {
                   child: Column(
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
-                      _SectionTitle('Historial'),
+                      const SectionTitle('Historial'),
                       const SizedBox(height: 12),
                       Column(
                         children: List.generate(r.statusHistory.length, (i) {
@@ -616,309 +621,6 @@ class ReserveDetailView extends GetView<ReserveDetailController> {
   }
 }
 
-class _HeaderCard extends StatelessWidget {
-  const _HeaderCard({
-    required this.name,
-    required this.email,
-    required this.statusText,
-    required this.bannerUrl,
-    required this.initial,
-  });
-
-  final String name;
-  final String email;
-  final String statusText;
-  final String bannerUrl; // <- logo del negocio
-  final String initial; // <- inicial del cliente
-
-  @override
-  Widget build(BuildContext context) {
-    final cs = Theme.of(context).colorScheme;
-    final tt = Theme.of(context).textTheme;
-
-    return SizedBox(
-      height: 150,
-      child: ClipRRect(
-        borderRadius: BorderRadius.circular(18),
-        child: Stack(
-          fit: StackFit.expand,
-          children: [
-            // Banner: logo del negocio
-            if (bannerUrl.isNotEmpty)
-              Image.network(
-                bannerUrl,
-                fit: BoxFit.cover,
-                errorBuilder: (_, __, ___) => Container(color: cs.surface),
-              )
-            else
-              Container(color: cs.surface),
-
-            // Overlay muy sutil (sin blur agresivo)
-            DecoratedBox(
-              decoration: BoxDecoration(
-                gradient: LinearGradient(
-                  colors: [
-                    cs.surface.withValues(alpha: .75),
-                    cs.surface.withValues(alpha: .75),
-                  ],
-                  begin: Alignment.topLeft,
-                  end: Alignment.bottomRight,
-                ),
-              ),
-            ),
-
-            // Contenido
-            Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 8),
-              child: Row(
-                children: [
-                  _InitialAvatar(initial: initial, size: 64),
-                  const SizedBox(width: 14),
-                  Expanded(
-                    child: Column(
-                      mainAxisAlignment: MainAxisAlignment.center, // centrado
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        Text(
-                          name,
-                          maxLines: 1,
-                          overflow: TextOverflow.ellipsis,
-                          style: tt.titleLarge!.copyWith(
-                            fontWeight: FontWeight.bold,
-                            fontSize: 20,
-                          ),
-                        ),
-                        const SizedBox(height: 4),
-                        if (email.trim().isNotEmpty)
-                          Text(
-                            email,
-                            maxLines: 1,
-                            overflow: TextOverflow.ellipsis,
-                            style: tt.bodyMedium!.copyWith(
-                              color: cs.onSurfaceVariant,
-                              fontWeight: FontWeight.bold,
-                            ),
-                          ),
-                      ],
-                    ),
-                  ),
-                ],
-              ),
-            ),
-          ],
-        ),
-      ),
-    );
-  }
-}
-
-/// Avatar con la inicial (gradiente del tema, borde blanco y sombra sutil)
-class _InitialAvatar extends StatelessWidget {
-  const _InitialAvatar({required this.initial, this.size = 56});
-
-  final String initial;
-  final double size;
-
-  @override
-  Widget build(BuildContext context) {
-    final cs = Theme.of(context).colorScheme;
-    final textStyle = Theme.of(context).textTheme.headlineSmall!.copyWith(
-      color: Colors.white,
-      fontWeight: FontWeight.w800,
-    );
-
-    return Container(
-      width: size,
-      height: size,
-      decoration: BoxDecoration(
-        shape: BoxShape.circle,
-        gradient: LinearGradient(
-          colors: [cs.primary, cs.secondary],
-          begin: Alignment.topLeft,
-          end: Alignment.bottomRight,
-        ),
-        boxShadow: [
-          BoxShadow(
-            color: cs.primary.withValues(alpha: .22),
-            blurRadius: 10,
-            offset: const Offset(0, 6),
-          ),
-        ],
-        border: Border.all(
-          color: Colors.white.withValues(alpha: .95),
-          width: 3,
-        ),
-      ),
-      alignment: Alignment.center,
-      child: FittedBox(
-        fit: BoxFit.scaleDown,
-        child: Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 6),
-          child: Text(initial, style: textStyle),
-        ),
-      ),
-    );
-  }
-}
-
-class _TimeChip extends StatelessWidget {
-  const _TimeChip({required this.icon, required this.label});
-  final IconData icon;
-  final String label;
-
-  @override
-  Widget build(BuildContext context) {
-    final cs = Theme.of(context).colorScheme;
-    return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
-      decoration: BoxDecoration(
-        color: cs.surfaceContainerHighest,
-        borderRadius: BorderRadius.circular(999),
-        border: Border.all(color: cs.outlineVariant),
-      ),
-      child: Row(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          Icon(icon, size: 16, color: cs.onSurfaceVariant),
-          const SizedBox(width: 6),
-          Text(
-            label,
-            style: Theme.of(
-              context,
-            ).textTheme.labelMedium!.copyWith(fontWeight: FontWeight.w700),
-          ),
-        ],
-      ),
-    );
-  }
-}
-
-class _InfoTile extends StatelessWidget {
-  const _InfoTile({
-    required this.icon,
-    required this.label,
-    required this.value,
-  });
-  final IconData icon;
-  final String label;
-  final String value;
-
-  @override
-  Widget build(BuildContext context) {
-    final cs = Theme.of(context).colorScheme;
-    final tt = Theme.of(context).textTheme;
-    return ConstrainedBox(
-      constraints: const BoxConstraints(minWidth: 120),
-      child: Row(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          Icon(icon, color: cs.primary),
-          const SizedBox(width: 8),
-          Flexible(
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Text(
-                  label,
-                  style: tt.labelSmall!.copyWith(
-                    color: cs.onSurfaceVariant,
-                    height: 1,
-                  ),
-                ),
-                const SizedBox(height: 2),
-                Text(
-                  value,
-                  maxLines: 1,
-                  overflow: TextOverflow.ellipsis,
-                  style: tt.titleSmall!.copyWith(fontWeight: FontWeight.w700),
-                ),
-              ],
-            ),
-          ),
-        ],
-      ),
-    );
-  }
-}
-
-class _SectionTitle extends StatelessWidget {
-  const _SectionTitle(this.text);
-  final String text;
-  @override
-  Widget build(BuildContext context) {
-    final tt = Theme.of(context).textTheme;
-    return Text(
-      text,
-      style: tt.titleMedium!.copyWith(fontWeight: FontWeight.w800),
-    );
-  }
-}
-
-class _ContactRow extends StatelessWidget {
-  const _ContactRow({
-    required this.icon,
-    required this.label,
-    required this.value,
-  });
-  final IconData icon;
-  final String label;
-  final String value;
-
-  @override
-  Widget build(BuildContext context) {
-    final cs = Theme.of(context).colorScheme;
-    final tt = Theme.of(context).textTheme;
-    return Padding(
-      padding: const EdgeInsets.only(bottom: 10),
-      child: Row(
-        children: [
-          Icon(icon, color: cs.onSurfaceVariant),
-          const SizedBox(width: 10),
-          Text(
-            label,
-            style: tt.labelMedium!.copyWith(color: cs.onSurfaceVariant),
-          ),
-          const SizedBox(width: 6),
-          Expanded(
-            child: Text(
-              value,
-              textAlign: TextAlign.end,
-              style: tt.bodyMedium!.copyWith(fontWeight: FontWeight.w700),
-            ),
-          ),
-        ],
-      ),
-    );
-  }
-}
-
-/// Colores fijos por estado
-class StatusPill extends StatelessWidget {
-  const StatusPill({super.key, required this.text});
-  final String text;
-
-  @override
-  Widget build(BuildContext context) {
-    final (bg, fg) = _statusColors(text);
-    return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
-      decoration: BoxDecoration(
-        color: bg,
-        borderRadius: BorderRadius.circular(999),
-        border: Border.all(color: fg.withValues(alpha: .25)),
-      ),
-      child: Text(
-        text,
-        style: Theme.of(context).textTheme.labelMedium!.copyWith(
-          color: fg,
-          fontWeight: FontWeight.w700,
-          letterSpacing: .2,
-        ),
-      ),
-    );
-  }
-}
-
 // ───────────── Helpers ─────────────
 DateTime _asLocal(dynamic dt) {
   if (dt is DateTime) return dt.toLocal();
@@ -943,16 +645,12 @@ String _normalizeStatus(String raw) {
   return raw.isEmpty ? 'Pendiente' : raw;
 }
 
-(Color, Color) _statusColors(String status) {
-  final s = status.toLowerCase();
-  if (s.contains('complet')) {
-    return (const Color(0xFFE6F4EA), const Color(0xFF0F5132));
-  } else if (s.contains('pend')) {
-    return (const Color(0xFFFFF4E5), const Color(0xFF7A4F01));
-  } else if (s.contains('confirm')) {
-    return (const Color(0xFFE7F1FF), const Color(0xFF084298));
-  } else if (s.contains('cancel')) {
-    return (const Color(0xFFFFE5E5), const Color(0xFF842029));
-  }
-  return (const Color(0xFFEDEDED), const Color(0xFF222222));
+Tone _toneForStatus(String raw) {
+  final s = raw.toLowerCase();
+  if (s.contains('complet')) return Tone.success;
+  if (s.contains('pend')) return Tone.warning;
+  if (s.contains('cancel')) return Tone.danger;
+  if (s.contains('confirm')) return Tone.info;
+  return Tone.info;
 }
+

--- a/mobile/rupu/lib/presentation/views/reserve/views/reserve_view.dart
+++ b/mobile/rupu/lib/presentation/views/reserve/views/reserve_view.dart
@@ -2,12 +2,11 @@
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:go_router/go_router.dart';
-import 'package:rupu/config/helpers/design_helper.dart';
 import 'package:rupu/presentation/views/views.dart';
-import 'dart:ui' show ImageFilter;
 import 'package:rupu/config/helpers/design_helper.dart' as design;
 
 import 'package:rupu/presentation/widgets/premium_reserve_card.dart';
+import '../widgets.dart';
 
 class ReserveView extends GetView<ReserveController> {
   const ReserveView({super.key, required this.pageIndex});
@@ -253,8 +252,8 @@ class ReserveView extends GetView<ReserveController> {
             padding: const EdgeInsets.fromLTRB(16, 12, 16, 24),
             children: [
               // ───────────────── Hero / Header ─────────────────
-              _PremiumHeader(
-                totalHoy: totalHoy,
+              ReserveHeader(
+                totalToday: totalHoy,
                 onNew: () => context.pushNamed(
                   'reserve_new',
                   pathParameters: {'page': '$pageIndex'},
@@ -267,7 +266,7 @@ class ReserveView extends GetView<ReserveController> {
               const SizedBox(height: 16),
 
               // ───────────────── Acciones rápidas (scroll horizontal) ─────────────────
-              _QuickActionsStrip(
+              QuickActionsStrip(
                 onNew: () => context.pushNamed(
                   'reserve_new',
                   pathParameters: {'page': '$pageIndex'},
@@ -302,7 +301,7 @@ class ReserveView extends GetView<ReserveController> {
                   ),
                 ),
               ] else if (controller.reservasHoy.isEmpty) ...[
-                _EmptyStateCard(
+                EmptyStateCard(
                   title: 'Sin reservas hoy',
                   message:
                       'Aún no tienes reservas para hoy. Crea la primera y aparecerá aquí.',
@@ -346,322 +345,6 @@ class ReserveView extends GetView<ReserveController> {
     );
   }
 }
-
-// ─────────────────────────────────────────────────────────────
-// HEADER PREMIUM (gradiente suave + CTA)
-// ─────────────────────────────────────────────────────────────
-class _PremiumHeader extends StatelessWidget {
-  const _PremiumHeader({
-    required this.totalHoy,
-    required this.onNew,
-    required this.onCalendar,
-  });
-
-  final int totalHoy;
-  final VoidCallback onNew;
-  final VoidCallback onCalendar;
-
-  @override
-  Widget build(BuildContext context) {
-    final cs = Theme.of(context).colorScheme;
-    final tt = Theme.of(context).textTheme;
-
-    return Container(
-      padding: const EdgeInsets.all(16),
-      decoration: BoxDecoration(
-        gradient: LinearGradient(
-          begin: Alignment.topLeft,
-          end: Alignment.bottomRight,
-          colors: [
-            cs.primary.withValues(alpha: .10),
-            cs.secondary.withValues(alpha: .08),
-          ],
-        ),
-        borderRadius: BorderRadius.circular(18),
-        border: Border.all(color: cs.outlineVariant),
-      ),
-      child: Row(
-        children: [
-          // Copy
-          Expanded(
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Text(
-                  'Agenda de hoy',
-                  style: tt.titleLarge!.copyWith(fontWeight: FontWeight.w800),
-                ),
-                const SizedBox(height: 4),
-                Text(
-                  totalHoy == 0
-                      ? 'No hay reservas registradas.'
-                      : '$totalHoy reserva${totalHoy == 1 ? '' : 's'} programada${totalHoy == 1 ? '' : 's'}.',
-                  style: tt.bodyMedium!.copyWith(
-                    color: cs.onSurfaceVariant,
-                    fontWeight: FontWeight.w600,
-                  ),
-                ),
-                const SizedBox(height: 12),
-                Wrap(
-                  spacing: 10,
-                  runSpacing: 10,
-                  children: [
-                    FilledButton.icon(
-                      onPressed: onNew,
-                      icon: const Icon(Icons.add_circle_outline),
-                      label: const Text('Nueva reserva'),
-                    ),
-                    OutlinedButton.icon(
-                      onPressed: onCalendar,
-                      icon: const Icon(Icons.event_outlined),
-                      label: const Text(
-                        'Calendario',
-                        style: TextStyle(fontSize: 12),
-                      ),
-                    ),
-                  ],
-                ),
-              ],
-            ),
-          ),
-          const SizedBox(width: 8),
-
-          // Ilustración simple (icono grande)
-        ],
-      ),
-    );
-  }
-}
-
-// ─────────────────────────────────────────────────────────────
-// QUICK ACTIONS (horizontal, cards fijos, sin overflows)
-// ─────────────────────────────────────────────────────────────
-class _QuickActionsStrip extends StatelessWidget {
-  const _QuickActionsStrip({
-    required this.onNew,
-    required this.onCalendar,
-    required this.onCheckIn,
-    required this.onClients,
-  });
-
-  final VoidCallback onNew;
-  final VoidCallback onCalendar;
-  final VoidCallback onCheckIn;
-  final VoidCallback onClients;
-
-  @override
-  Widget build(BuildContext context) {
-    final items = [
-      ('Nueva', Icons.add_circle_outline, onNew),
-      ('Calendario', Icons.event_outlined, onCalendar),
-      // ('Check-in', Icons.how_to_reg_outlined, onCheckIn),
-      ('Clientes', Icons.person_outline, onClients),
-    ];
-
-    return SizedBox(
-      height: 100,
-      child: ListView.separated(
-        scrollDirection: Axis.horizontal,
-        itemCount: items.length,
-        separatorBuilder: (_, __) => const SizedBox(width: 12),
-        padding: const EdgeInsets.symmetric(horizontal: 2),
-        itemBuilder: (_, i) {
-          final (label, icon, handler) = items[i];
-          return _QuickCard(label: label, icon: icon, onTap: handler);
-        },
-      ),
-    );
-  }
-}
-
-class _QuickCard extends StatelessWidget {
-  const _QuickCard({required this.label, required this.icon, this.onTap});
-  final String label;
-  final IconData icon;
-  final VoidCallback? onTap;
-
-  @override
-  Widget build(BuildContext context) {
-    final cs = Theme.of(context).colorScheme;
-    final tt = Theme.of(context).textTheme;
-
-    return ClipRRect(
-      borderRadius: BorderRadius.circular(18),
-      child: BackdropFilter(
-        filter: ImageFilter.blur(sigmaX: 10, sigmaY: 10),
-        child: Material(
-          color: Colors.transparent,
-          child: InkWell(
-            onTap: onTap,
-            borderRadius: BorderRadius.circular(18),
-            child: Ink(
-              width: 120, // ancho cómodo para 2 líneas de texto
-              height: 120,
-              decoration: BoxDecoration(
-                color: cs.surfaceContainerHighest.withValues(alpha: .35),
-                borderRadius: BorderRadius.circular(18),
-                border: Border.all(
-                  color: cs.outlineVariant.withValues(alpha: .5),
-                ),
-              ),
-              child: Center(
-                child: Column(
-                  mainAxisSize: MainAxisSize.min,
-                  children: [
-                    // Icono en píldora circular
-                    Container(
-                      width: 44,
-                      height: 44,
-                      decoration: BoxDecoration(
-                        shape: BoxShape.circle,
-                        gradient: LinearGradient(
-                          colors: [
-                            cs.primary.withValues(alpha: .14),
-                            cs.secondary.withValues(alpha: .12),
-                          ],
-                        ),
-                        // aro sutil
-                        boxShadow: [
-                          BoxShadow(
-                            color: Colors.black.withValues(alpha: .06),
-                            blurRadius: 12,
-                            offset: const Offset(0, 6),
-                          ),
-                        ],
-                      ),
-                      alignment: Alignment.center,
-                      child: Icon(icon, color: cs.primary),
-                    ),
-                    const SizedBox(height: 10),
-                    // Texto centrado (2 líneas máx)
-                    Padding(
-                      padding: const EdgeInsets.symmetric(horizontal: 8),
-                      child: Text(
-                        label,
-                        textAlign: TextAlign.center,
-                        maxLines: 2,
-                        overflow: TextOverflow.ellipsis,
-                        style: tt.labelLarge!.copyWith(
-                          fontWeight: FontWeight.w800,
-                          letterSpacing: .2,
-                        ),
-                      ),
-                    ),
-                  ],
-                ),
-              ),
-            ),
-          ),
-        ),
-      ),
-    );
-  }
-}
-
-class SoftStatusPill extends StatelessWidget {
-  const SoftStatusPill({super.key, required this.text, required this.tone});
-  final String text;
-  final StatusTone tone;
-
-  @override
-  Widget build(BuildContext context) {
-    final cs = Theme.of(context).colorScheme;
-
-    Color fg;
-    switch (tone) {
-      case StatusTone.success:
-        fg = Colors.green;
-        break;
-      case StatusTone.warning:
-        fg = const Color(0xFF9E6B00);
-        break; // ámbar oscuro
-      case StatusTone.danger:
-        fg = cs.error;
-        break;
-      case StatusTone.info:
-        fg = cs.primary;
-        break;
-    }
-
-    return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
-      decoration: ShapeDecoration(
-        color: fg.withValues(alpha: .12),
-        shape: StadiumBorder(
-          side: BorderSide(color: fg.withValues(alpha: .22)),
-        ),
-      ),
-      child: Text(
-        text,
-        style: TextStyle(color: fg, fontWeight: FontWeight.w800, fontSize: 12),
-      ),
-    );
-  }
-}
-
 // ─────────────────────────────────────────────────────────────
 // Empty state amigable
 // ─────────────────────────────────────────────────────────────
-class _EmptyStateCard extends StatelessWidget {
-  const _EmptyStateCard({
-    required this.title,
-    required this.message,
-    required this.ctaText,
-    required this.onCta,
-  });
-
-  final String title;
-  final String message;
-  final String ctaText;
-  final VoidCallback onCta;
-
-  @override
-  Widget build(BuildContext context) {
-    final cs = Theme.of(context).colorScheme;
-    final tt = Theme.of(context).textTheme;
-
-    return PrimaryCard(
-      child: Padding(
-        padding: const EdgeInsets.fromLTRB(16, 18, 16, 16),
-        child: Row(
-          children: [
-            Container(
-              width: 44,
-              height: 44,
-              decoration: BoxDecoration(
-                color: cs.primary.withValues(alpha: .12),
-                borderRadius: BorderRadius.circular(10),
-              ),
-              alignment: Alignment.center,
-              child: Icon(Icons.event_busy, color: cs.primary),
-            ),
-            const SizedBox(width: 12),
-            Expanded(
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Text(
-                    title,
-                    style: tt.titleMedium!.copyWith(
-                      fontWeight: FontWeight.w800,
-                    ),
-                  ),
-                  const SizedBox(height: 6),
-                  Text(
-                    message,
-                    style: tt.bodyMedium!.copyWith(color: cs.onSurfaceVariant),
-                  ),
-                  const SizedBox(height: 10),
-                  Align(
-                    alignment: Alignment.centerLeft,
-                    child: FilledButton(onPressed: onCta, child: Text(ctaText)),
-                  ),
-                ],
-              ),
-            ),
-          ],
-        ),
-      ),
-    );
-  }
-}

--- a/mobile/rupu/lib/presentation/views/reserve/views/update_reserve_view.dart
+++ b/mobile/rupu/lib/presentation/views/reserve/views/update_reserve_view.dart
@@ -4,7 +4,7 @@ import 'package:get/get.dart';
 import 'package:intl/intl.dart';
 import 'package:flutter/services.dart';
 
-import 'package:rupu/presentation/views/reserve/widgets/data_time_tile.dart';
+import '../widgets.dart';
 import '../controllers/reserve_update_controller.dart';
 import '../controllers/reserves_controller.dart';
 import '../controllers/reserve_status_controller.dart';

--- a/mobile/rupu/lib/presentation/views/reserve/widgets.dart
+++ b/mobile/rupu/lib/presentation/views/reserve/widgets.dart
@@ -1,0 +1,15 @@
+export 'widgets/add_event_sheet.dart';
+export 'widgets/appointment_detail_sheet.dart';
+export 'widgets/calendar_compact_toolbar.dart';
+export 'widgets/confirm_row.dart';
+export 'widgets/contact_row.dart';
+export 'widgets/date_tile.dart';
+export 'widgets/data_time_tile.dart';
+export 'widgets/empty_state_card.dart';
+export 'widgets/header_card.dart';
+export 'widgets/info_tile.dart';
+export 'widgets/quick_actions_strip.dart';
+export 'widgets/reserve_calendar.dart';
+export 'widgets/reserve_header.dart';
+export 'widgets/time_chip.dart';
+export 'widgets/sheets.dart';

--- a/mobile/rupu/lib/presentation/views/reserve/widgets/confirm_row.dart
+++ b/mobile/rupu/lib/presentation/views/reserve/widgets/confirm_row.dart
@@ -1,0 +1,39 @@
+import 'package:flutter/material.dart';
+
+class ConfirmRow extends StatelessWidget {
+  const ConfirmRow({
+    super.key,
+    required this.icon,
+    required this.label,
+    required this.value,
+  });
+
+  final IconData icon;
+  final String label;
+  final String value;
+
+  @override
+  Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+    final tt = Theme.of(context).textTheme;
+    return Row(
+      children: [
+        Icon(icon, size: 18, color: cs.onSurfaceVariant),
+        const SizedBox(width: 8),
+        Text(
+          label,
+          style: tt.labelMedium!.copyWith(color: cs.onSurfaceVariant),
+        ),
+        const SizedBox(width: 60),
+        Flexible(
+          child: Text(
+            value,
+            textAlign: TextAlign.end,
+            overflow: TextOverflow.ellipsis,
+            style: tt.bodyMedium!.copyWith(fontWeight: FontWeight.w700),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/mobile/rupu/lib/presentation/views/reserve/widgets/contact_row.dart
+++ b/mobile/rupu/lib/presentation/views/reserve/widgets/contact_row.dart
@@ -1,0 +1,41 @@
+import 'package:flutter/material.dart';
+
+class ContactRow extends StatelessWidget {
+  const ContactRow({
+    super.key,
+    required this.icon,
+    required this.label,
+    required this.value,
+  });
+
+  final IconData icon;
+  final String label;
+  final String value;
+
+  @override
+  Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+    final tt = Theme.of(context).textTheme;
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 10),
+      child: Row(
+        children: [
+          Icon(icon, color: cs.onSurfaceVariant),
+          const SizedBox(width: 10),
+          Text(
+            label,
+            style: tt.labelMedium!.copyWith(color: cs.onSurfaceVariant),
+          ),
+          const SizedBox(width: 6),
+          Expanded(
+            child: Text(
+              value,
+              textAlign: TextAlign.end,
+              style: tt.bodyMedium!.copyWith(fontWeight: FontWeight.w700),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/mobile/rupu/lib/presentation/views/reserve/widgets/date_tile.dart
+++ b/mobile/rupu/lib/presentation/views/reserve/widgets/date_tile.dart
@@ -1,0 +1,57 @@
+import 'package:flutter/material.dart';
+
+class DateTile extends StatelessWidget {
+  const DateTile({
+    super.key,
+    required this.label,
+    required this.value,
+    required this.icon,
+    required this.onTap,
+  });
+
+  final String label;
+  final String value;
+  final IconData icon;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+    final tt = Theme.of(context).textTheme;
+    return InkWell(
+      borderRadius: BorderRadius.circular(12),
+      onTap: onTap,
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 12),
+        decoration: BoxDecoration(
+          color: cs.surface,
+          borderRadius: BorderRadius.circular(12),
+          border: Border.all(color: cs.outlineVariant),
+        ),
+        child: Row(
+          children: [
+            Icon(icon, color: cs.primary),
+            const SizedBox(width: 10),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    label,
+                    style: tt.labelMedium!.copyWith(color: cs.onSurfaceVariant),
+                  ),
+                  const SizedBox(height: 4),
+                  Text(
+                    value,
+                    style: tt.titleSmall!.copyWith(fontWeight: FontWeight.w700),
+                  ),
+                ],
+              ),
+            ),
+            const Icon(Icons.edit_calendar_outlined),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/mobile/rupu/lib/presentation/views/reserve/widgets/empty_state_card.dart
+++ b/mobile/rupu/lib/presentation/views/reserve/widgets/empty_state_card.dart
@@ -1,0 +1,67 @@
+import 'package:flutter/material.dart';
+import 'package:rupu/config/helpers/design_helper.dart';
+
+class EmptyStateCard extends StatelessWidget {
+  const EmptyStateCard({
+    super.key,
+    required this.title,
+    required this.message,
+    required this.ctaText,
+    required this.onCta,
+  });
+
+  final String title;
+  final String message;
+  final String ctaText;
+  final VoidCallback onCta;
+
+  @override
+  Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+    final tt = Theme.of(context).textTheme;
+
+    return PrimaryCard(
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(16, 18, 16, 16),
+        child: Row(
+          children: [
+            Container(
+              width: 44,
+              height: 44,
+              decoration: BoxDecoration(
+                color: cs.primary.withValues(alpha: .12),
+                borderRadius: BorderRadius.circular(10),
+              ),
+              alignment: Alignment.center,
+              child: Icon(Icons.event_busy, color: cs.primary),
+            ),
+            const SizedBox(width: 12),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    title,
+                    style: tt.titleMedium!.copyWith(
+                      fontWeight: FontWeight.w800,
+                    ),
+                  ),
+                  const SizedBox(height: 6),
+                  Text(
+                    message,
+                    style: tt.bodyMedium!.copyWith(color: cs.onSurfaceVariant),
+                  ),
+                  const SizedBox(height: 10),
+                  Align(
+                    alignment: Alignment.centerLeft,
+                    child: FilledButton(onPressed: onCta, child: Text(ctaText)),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/mobile/rupu/lib/presentation/views/reserve/widgets/header_card.dart
+++ b/mobile/rupu/lib/presentation/views/reserve/widgets/header_card.dart
@@ -1,0 +1,92 @@
+import 'package:flutter/material.dart';
+import 'package:rupu/presentation/widgets/widgets.dart';
+
+class HeaderCard extends StatelessWidget {
+  const HeaderCard({
+    super.key,
+    required this.name,
+    required this.email,
+    required this.bannerUrl,
+    required this.initial,
+  });
+
+  final String name;
+  final String email;
+  final String bannerUrl;
+  final String initial;
+
+  @override
+  Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+    final tt = Theme.of(context).textTheme;
+
+    return SizedBox(
+      height: 150,
+      child: ClipRRect(
+        borderRadius: BorderRadius.circular(18),
+        child: Stack(
+          fit: StackFit.expand,
+          children: [
+            if (bannerUrl.isNotEmpty)
+              Image.network(
+                bannerUrl,
+                fit: BoxFit.cover,
+                errorBuilder: (_, __, ___) => Container(color: cs.surface),
+              )
+            else
+              Container(color: cs.surface),
+            DecoratedBox(
+              decoration: BoxDecoration(
+                gradient: LinearGradient(
+                  colors: [
+                    cs.surface.withValues(alpha: .75),
+                    cs.surface.withValues(alpha: .75),
+                  ],
+                  begin: Alignment.topLeft,
+                  end: Alignment.bottomRight,
+                ),
+              ),
+            ),
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 8),
+              child: Row(
+                children: [
+                  InitialAvatar(initial: initial, size: 64),
+                  const SizedBox(width: 14),
+                  Expanded(
+                    child: Column(
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          name,
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                          style: tt.titleLarge!.copyWith(
+                            fontWeight: FontWeight.bold,
+                            fontSize: 20,
+                          ),
+                        ),
+                        const SizedBox(height: 4),
+                        if (email.trim().isNotEmpty)
+                          Text(
+                            email,
+                            maxLines: 1,
+                            overflow: TextOverflow.ellipsis,
+                            style: tt.bodyMedium!.copyWith(
+                              color: cs.onSurfaceVariant,
+                              fontWeight: FontWeight.bold,
+                            ),
+                          ),
+                      ],
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/mobile/rupu/lib/presentation/views/reserve/widgets/info_tile.dart
+++ b/mobile/rupu/lib/presentation/views/reserve/widgets/info_tile.dart
@@ -1,0 +1,49 @@
+import 'package:flutter/material.dart';
+
+class InfoTile extends StatelessWidget {
+  const InfoTile({
+    super.key,
+    required this.icon,
+    required this.label,
+    required this.value,
+  });
+
+  final IconData icon;
+  final String label;
+  final String value;
+
+  @override
+  Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+    final tt = Theme.of(context).textTheme;
+    return ConstrainedBox(
+      constraints: const BoxConstraints(minWidth: 120),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(icon, color: cs.primary),
+          const SizedBox(width: 8),
+          Flexible(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  label,
+                  style: tt.labelSmall!
+                      .copyWith(color: cs.onSurfaceVariant, height: 1),
+                ),
+                const SizedBox(height: 2),
+                Text(
+                  value,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: tt.titleSmall!.copyWith(fontWeight: FontWeight.w700),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/mobile/rupu/lib/presentation/views/reserve/widgets/quick_actions_strip.dart
+++ b/mobile/rupu/lib/presentation/views/reserve/widgets/quick_actions_strip.dart
@@ -1,0 +1,122 @@
+import 'dart:ui' show ImageFilter;
+import 'package:flutter/material.dart';
+
+class QuickActionsStrip extends StatelessWidget {
+  const QuickActionsStrip({
+    super.key,
+    required this.onNew,
+    required this.onCalendar,
+    required this.onCheckIn,
+    required this.onClients,
+  });
+
+  final VoidCallback onNew;
+  final VoidCallback onCalendar;
+  final VoidCallback onCheckIn;
+  final VoidCallback onClients;
+
+  @override
+  Widget build(BuildContext context) {
+    final items = [
+      ('Nueva', Icons.add_circle_outline, onNew),
+      ('Calendario', Icons.event_outlined, onCalendar),
+      // ('Check-in', Icons.how_to_reg_outlined, onCheckIn),
+      ('Clientes', Icons.person_outline, onClients),
+    ];
+
+    return SizedBox(
+      height: 100,
+      child: ListView.separated(
+        scrollDirection: Axis.horizontal,
+        itemCount: items.length,
+        separatorBuilder: (_, __) => const SizedBox(width: 12),
+        padding: const EdgeInsets.symmetric(horizontal: 2),
+        itemBuilder: (_, i) {
+          final (label, icon, handler) = items[i];
+          return _QuickCard(label: label, icon: icon, onTap: handler);
+        },
+      ),
+    );
+  }
+}
+
+class _QuickCard extends StatelessWidget {
+  const _QuickCard({required this.label, required this.icon, this.onTap});
+  final String label;
+  final IconData icon;
+  final VoidCallback? onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+    final tt = Theme.of(context).textTheme;
+
+    return ClipRRect(
+      borderRadius: BorderRadius.circular(18),
+      child: BackdropFilter(
+        filter: ImageFilter.blur(sigmaX: 10, sigmaY: 10),
+        child: Material(
+          color: Colors.transparent,
+          child: InkWell(
+            onTap: onTap,
+            borderRadius: BorderRadius.circular(18),
+            child: Ink(
+              width: 120,
+              height: 120,
+              decoration: BoxDecoration(
+                color: cs.surfaceContainerHighest.withValues(alpha: .35),
+                borderRadius: BorderRadius.circular(18),
+                border: Border.all(
+                  color: cs.outlineVariant.withValues(alpha: .5),
+                ),
+              ),
+              child: Center(
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Container(
+                      width: 44,
+                      height: 44,
+                      decoration: BoxDecoration(
+                        shape: BoxShape.circle,
+                        gradient: LinearGradient(
+                          colors: [
+                            cs.primary.withValues(alpha: .14),
+                            cs.secondary.withValues(alpha: .12),
+                          ],
+                        ),
+                        boxShadow: [
+                          BoxShadow(
+                            color: Colors.black.withValues(alpha: .06),
+                            blurRadius: 12,
+                            offset: const Offset(0, 6),
+                          ),
+                        ],
+                      ),
+                      alignment: Alignment.center,
+                      child: Icon(icon, color: cs.primary),
+                    ),
+                    const SizedBox(height: 10),
+                    Padding(
+                      padding: const EdgeInsets.symmetric(horizontal: 8),
+                      child: Text(
+                        label,
+                        textAlign: TextAlign.center,
+                        maxLines: 2,
+                        overflow: TextOverflow.ellipsis,
+                        style: tt.labelLarge!.copyWith(
+                          fontWeight: FontWeight.w800,
+                          letterSpacing: .2,
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/mobile/rupu/lib/presentation/views/reserve/widgets/reserve_header.dart
+++ b/mobile/rupu/lib/presentation/views/reserve/widgets/reserve_header.dart
@@ -1,0 +1,82 @@
+import 'package:flutter/material.dart';
+
+class ReserveHeader extends StatelessWidget {
+  const ReserveHeader({
+    super.key,
+    required this.totalToday,
+    required this.onNew,
+    required this.onCalendar,
+  });
+
+  final int totalToday;
+  final VoidCallback onNew;
+  final VoidCallback onCalendar;
+
+  @override
+  Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+    final tt = Theme.of(context).textTheme;
+
+    return Container(
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        gradient: LinearGradient(
+          begin: Alignment.topLeft,
+          end: Alignment.bottomRight,
+          colors: [
+            cs.primary.withValues(alpha: .10),
+            cs.secondary.withValues(alpha: .08),
+          ],
+        ),
+        borderRadius: BorderRadius.circular(18),
+        border: Border.all(color: cs.outlineVariant),
+      ),
+      child: Row(
+        children: [
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  'Agenda de hoy',
+                  style: tt.titleLarge!.copyWith(fontWeight: FontWeight.w800),
+                ),
+                const SizedBox(height: 4),
+                Text(
+                  totalToday == 0
+                      ? 'No hay reservas registradas.'
+                      : '$totalToday reserva${totalToday == 1 ? '' : 's'} programada${totalToday == 1 ? '' : 's'}.',
+                  style: tt.bodyMedium!.copyWith(
+                    color: cs.onSurfaceVariant,
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+                const SizedBox(height: 12),
+                Wrap(
+                  spacing: 10,
+                  runSpacing: 10,
+                  children: [
+                    FilledButton.icon(
+                      onPressed: onNew,
+                      icon: const Icon(Icons.add_circle_outline),
+                      label: const Text('Nueva reserva'),
+                    ),
+                    OutlinedButton.icon(
+                      onPressed: onCalendar,
+                      icon: const Icon(Icons.event_outlined),
+                      label: const Text(
+                        'Calendario',
+                        style: TextStyle(fontSize: 12),
+                      ),
+                    ),
+                  ],
+                ),
+              ],
+            ),
+          ),
+          const SizedBox(width: 8),
+        ],
+      ),
+    );
+  }
+}

--- a/mobile/rupu/lib/presentation/views/reserve/widgets/time_chip.dart
+++ b/mobile/rupu/lib/presentation/views/reserve/widgets/time_chip.dart
@@ -1,0 +1,35 @@
+import 'package:flutter/material.dart';
+
+class TimeChip extends StatelessWidget {
+  const TimeChip({super.key, required this.icon, required this.label});
+
+  final IconData icon;
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+      decoration: BoxDecoration(
+        color: cs.surfaceContainerHighest,
+        borderRadius: BorderRadius.circular(999),
+        border: Border.all(color: cs.outlineVariant),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(icon, size: 16, color: cs.onSurfaceVariant),
+          const SizedBox(width: 6),
+          Text(
+            label,
+            style: Theme.of(context)
+                .textTheme
+                .labelMedium!
+                .copyWith(fontWeight: FontWeight.w700),
+          ),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add widgets barrel for reserve module
- extract and reuse widgets to simplify reserve views
- leverage shared status pill and initial avatar

## Testing
- `dart format mobile/rupu/lib/presentation/views/reserve/widgets.dart` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c6346746d0832a8493add3c33dc26f