### PR TITLE
feat: add settings view with user management

### DIFF
--- a/mobile/rupu/lib/config/routers/app_bindings.dart
+++ b/mobile/rupu/lib/config/routers/app_bindings.dart
@@ -66,3 +66,19 @@ class ClientsBinding {
     }
   }
 }
+
+class SettingsBinding {
+  static void register() {
+    if (!Get.isRegistered<SettingsController>()) {
+      Get.put(SettingsController());
+    }
+  }
+}
+
+class CreateUserBinding {
+  static void register() {
+    if (!Get.isRegistered<CreateUserController>()) {
+      Get.put(CreateUserController());
+    }
+  }
+}

--- a/mobile/rupu/lib/config/routers/app_router.dart
+++ b/mobile/rupu/lib/config/routers/app_router.dart
@@ -10,8 +10,8 @@ import '../../presentation/views/views.dart';
 final _shellNavigatorKey = GlobalKey<NavigatorState>();
 
 int _calculateIndex(String location) {
-  if (location.endsWith('/perfil')) return 1;
-  if (location.startsWith('/home/') && !location.contains('/')) return 0;
+  if (location.contains('/perfil')) return 1;
+  if (location.contains('/ajustes')) return 2;
   return 0;
 }
 
@@ -113,6 +113,34 @@ final appRouter = GoRouter(
           builder: (context, state) {
             CambiarContrasenaBinding.register();
             return CambiarContrasenaScreen();
+          },
+        ),
+
+        GoRoute(
+          path: '/home/:page/ajustes',
+          name: SettingsScreen.name,
+          builder: (context, state) {
+            final pageIndex = int.parse(state.pathParameters['page']!);
+            SettingsBinding.register();
+            return FadeInLeft(
+              curve: Curves.fastEaseInToSlowEaseOut,
+              delay: const Duration(milliseconds: 200),
+              child: SettingsView(pageIndex: pageIndex),
+            );
+          },
+        ),
+        GoRoute(
+          path: '/home/:page/ajustes/crear_usuario',
+          name: CreateUserView.name,
+          builder: (context, state) {
+            CreateUserBinding.register();
+            final home = Get.find<HomeController>();
+            if (!home.isSuper) {
+              return const Scaffold(
+                body: Center(child: Text('No autorizado')),
+              );
+            }
+            return const CreateUserView();
           },
         ),
 

--- a/mobile/rupu/lib/presentation/screens/screens.dart
+++ b/mobile/rupu/lib/presentation/screens/screens.dart
@@ -7,3 +7,5 @@ export 'package:rupu/presentation/screens/home/home_screen.dart';
 export 'package:rupu/presentation/screens/cambiar_contrasena/cambiar_contrasena_screen.dart';
 
 export 'package:rupu/presentation/screens/login/login_screen.dart';
+
+export 'package:rupu/presentation/screens/settings/settings_screen.dart';

--- a/mobile/rupu/lib/presentation/screens/settings/settings_screen.dart
+++ b/mobile/rupu/lib/presentation/screens/settings/settings_screen.dart
@@ -1,0 +1,21 @@
+import 'package:flutter/material.dart';
+
+import '../../views/views.dart';
+
+class SettingsScreen extends StatelessWidget {
+  static const name = 'settings-screen';
+  final int pageIndex;
+
+  const SettingsScreen({super.key, required this.pageIndex});
+
+  @override
+  Widget build(BuildContext context) {
+    final viewRoutes = <Widget>[
+      SettingsView(pageIndex: pageIndex),
+      const SizedBox(),
+    ];
+    return Scaffold(
+      body: IndexedStack(index: pageIndex, children: viewRoutes),
+    );
+  }
+}

--- a/mobile/rupu/lib/presentation/views/settings/create_user_controller.dart
+++ b/mobile/rupu/lib/presentation/views/settings/create_user_controller.dart
@@ -1,0 +1,4 @@
+// presentation/views/settings/create_user_controller.dart
+import 'package:get/get.dart';
+
+class CreateUserController extends GetxController {}

--- a/mobile/rupu/lib/presentation/views/settings/create_user_view.dart
+++ b/mobile/rupu/lib/presentation/views/settings/create_user_view.dart
@@ -1,0 +1,20 @@
+// presentation/views/settings/create_user_view.dart
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+
+import 'create_user_controller.dart';
+
+class CreateUserView extends GetView<CreateUserController> {
+  static const name = 'create-user';
+  const CreateUserView({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Crear usuario')),
+      body: const Center(
+        child: Text('Vista de creación de usuario (dummy)'),
+      ),
+    );
+  }
+}

--- a/mobile/rupu/lib/presentation/views/settings/settings_controller.dart
+++ b/mobile/rupu/lib/presentation/views/settings/settings_controller.dart
@@ -1,0 +1,24 @@
+// presentation/views/settings/settings_controller.dart
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+import 'package:go_router/go_router.dart';
+import 'package:rupu/config/theme/app_theme_controller.dart';
+import 'package:rupu/presentation/views/home/home_controller.dart';
+
+import 'create_user_view.dart';
+
+class SettingsController extends GetxController {
+  final AppThemeController _themeCtrl = Get.find<AppThemeController>();
+  final HomeController _homeCtrl = Get.find<HomeController>();
+
+  RxBool get isDarkRx => _themeCtrl.isDark;
+  bool get isAdmin => _homeCtrl.isSuper;
+
+  void toggleTheme() => _themeCtrl.toggleTheme();
+
+  void goToCreateUser(BuildContext context, int pageIndex) {
+    if (!isAdmin) return;
+    GoRouter.of(context)
+        .pushNamed(CreateUserView.name, pathParameters: {'page': '$pageIndex'});
+  }
+}

--- a/mobile/rupu/lib/presentation/views/settings/settings_view.dart
+++ b/mobile/rupu/lib/presentation/views/settings/settings_view.dart
@@ -1,0 +1,37 @@
+// presentation/views/settings/settings_view.dart
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+
+import 'settings_controller.dart';
+
+class SettingsView extends GetView<SettingsController> {
+  static const name = 'settings-screen';
+  final int pageIndex;
+  const SettingsView({super.key, required this.pageIndex});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Ajustes')),
+      body: ListView(
+        children: [
+          Obx(() {
+            final isDark = controller.isDarkRx.value;
+            return SwitchListTile.adaptive(
+              title: Text(isDark ? 'Modo Oscuro' : 'Modo Claro'),
+              secondary: Icon(isDark ? Icons.nights_stay : Icons.wb_sunny),
+              value: isDark,
+              onChanged: (_) => controller.toggleTheme(),
+            );
+          }),
+          if (controller.isAdmin)
+            ListTile(
+              leading: const Icon(Icons.person_add),
+              title: const Text('Crear usuario'),
+              onTap: () => controller.goToCreateUser(context, pageIndex),
+            ),
+        ],
+      ),
+    );
+  }
+}

--- a/mobile/rupu/lib/presentation/views/views.dart
+++ b/mobile/rupu/lib/presentation/views/views.dart
@@ -30,3 +30,8 @@ export 'package:rupu/presentation/views/change_password/cambiar_contrasena_view.
 export 'package:rupu/presentation/views/login/login_controller.dart';
 
 export 'package:rupu/presentation/views/login/login_view.dart';
+
+export 'package:rupu/presentation/views/settings/settings_controller.dart';
+export 'package:rupu/presentation/views/settings/settings_view.dart';
+export 'package:rupu/presentation/views/settings/create_user_controller.dart';
+export 'package:rupu/presentation/views/settings/create_user_view.dart';

--- a/mobile/rupu/lib/presentation/widgets/shared/custom_bottom_navigation.dart
+++ b/mobile/rupu/lib/presentation/widgets/shared/custom_bottom_navigation.dart
@@ -17,7 +17,7 @@ class CustomBottomNavigation extends StatelessWidget {
         context.go('/home/0/perfil');
         break;
       case 2:
-        context.go('/home/0/perfil');
+        context.go('/home/0/ajustes');
         break;
     }
   }


### PR DESCRIPTION
## Summary
- add settings view with theme toggle
- wire bottom navigation to new settings routes
- scaffold dummy create-user screen restricted to admins

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c702a3b0e4832abc3acde148f9efc6