### PR TITLE
feat(mobile): add user management module

### DIFF
--- a/mobile/rupu/lib/config/routers/app_bindings.dart
+++ b/mobile/rupu/lib/config/routers/app_bindings.dart
@@ -67,6 +67,14 @@ class ClientsBinding {
   }
 }
 
+class UsersBinding {
+  static void register() {
+    if (!Get.isRegistered<UsersController>()) {
+      Get.put(UsersController());
+    }
+  }
+}
+
 class SettingsBinding {
   static void register() {
     if (!Get.isRegistered<SettingsController>()) {

--- a/mobile/rupu/lib/config/routers/app_router.dart
+++ b/mobile/rupu/lib/config/routers/app_router.dart
@@ -72,6 +72,29 @@ final appRouter = GoRouter(
           },
         ),
         GoRoute(
+          path: '/home/:page/users',
+          name: UsersView.name,
+          builder: (context, state) {
+            UsersBinding.register();
+            final page = int.parse(state.pathParameters['page']!);
+            return UsersView(pageIndex: page);
+          },
+        ),
+        GoRoute(
+          path: '/home/:page/users/create',
+          name: CreateUserView.name,
+          builder: (context, state) {
+            CreateUserBinding.register();
+            final home = Get.find<HomeController>();
+            if (!home.isSuper) {
+              return const Scaffold(
+                body: Center(child: Text('No autorizado')),
+              );
+            }
+            return const CreateUserView();
+          },
+        ),
+        GoRoute(
           path: '/home/:page/reserve/new',
           name: 'reserve_new',
           builder: (context, state) {
@@ -129,21 +152,6 @@ final appRouter = GoRouter(
             );
           },
         ),
-        GoRoute(
-          path: '/home/:page/ajustes/crear_usuario',
-          name: CreateUserView.name,
-          builder: (context, state) {
-            CreateUserBinding.register();
-            final home = Get.find<HomeController>();
-            if (!home.isSuper) {
-              return const Scaffold(
-                body: Center(child: Text('No autorizado')),
-              );
-            }
-            return const CreateUserView();
-          },
-        ),
-
         GoRoute(
           path: '/home/:page/perfil',
           name: PerfilScreen.name,

--- a/mobile/rupu/lib/domain/datasource/user_management_datasource.dart
+++ b/mobile/rupu/lib/domain/datasource/user_management_datasource.dart
@@ -1,0 +1,15 @@
+import '../infrastructure/models/users_response_model.dart';
+
+abstract class UserManagementDatasource {
+  Future<UsersResponseModel> getUsers({Map<String, dynamic>? query});
+  Future<void> createUser({
+    required String name,
+    required String email,
+    String? phone,
+    bool isActive = true,
+    List<int>? roleIds,
+    List<int>? businessIds,
+    String? avatarUrl,
+    String? avatarPath,
+  });
+}

--- a/mobile/rupu/lib/domain/entities/user_list_item.dart
+++ b/mobile/rupu/lib/domain/entities/user_list_item.dart
@@ -1,0 +1,17 @@
+class UserListItem {
+  final int id;
+  final String name;
+  final String email;
+  final String phone;
+  final String avatarUrl;
+  final bool isActive;
+
+  UserListItem({
+    required this.id,
+    required this.name,
+    required this.email,
+    required this.phone,
+    required this.avatarUrl,
+    required this.isActive,
+  });
+}

--- a/mobile/rupu/lib/domain/infrastructure/datasources/users_management_datasource_impl.dart
+++ b/mobile/rupu/lib/domain/infrastructure/datasources/users_management_datasource_impl.dart
@@ -1,0 +1,41 @@
+import 'package:dio/dio.dart';
+import '../../datasource/user_management_datasource.dart';
+import '../models/users_response_model.dart';
+
+class UsersManagementDatasourceImpl extends UserManagementDatasource {
+  final dio = Dio(BaseOptions(baseUrl: 'https://www.xn--rup-joa.com/api/v1'));
+
+  @override
+  Future<UsersResponseModel> getUsers({Map<String, dynamic>? query}) async {
+    final response = await dio.get('/users', queryParameters: query);
+    return UsersResponseModel.fromJson(response.data as Map<String, dynamic>);
+  }
+
+  @override
+  Future<void> createUser({
+    required String name,
+    required String email,
+    String? phone,
+    bool isActive = true,
+    List<int>? roleIds,
+    List<int>? businessIds,
+    String? avatarUrl,
+    String? avatarPath,
+  }) async {
+    final formData = FormData.fromMap({
+      'name': name,
+      'email': email,
+      if (phone != null) 'phone': phone,
+      'is_active': isActive,
+      if (roleIds != null) 'role_ids': roleIds,
+      if (businessIds != null) 'business_ids': businessIds,
+      if (avatarUrl != null) 'avatar_url': avatarUrl,
+      if (avatarPath != null)
+        'avatarFile': await MultipartFile.fromFile(
+          avatarPath,
+          filename: avatarPath.split('/').last,
+        ),
+    });
+    await dio.post('/users', data: formData);
+  }
+}

--- a/mobile/rupu/lib/domain/infrastructure/mappers/users_mapper.dart
+++ b/mobile/rupu/lib/domain/infrastructure/mappers/users_mapper.dart
@@ -1,0 +1,13 @@
+import 'package:rupu/domain/entities/user_list_item.dart';
+import '../models/users_response_model.dart';
+
+class UsersMapper {
+  static UserListItem userModelToEntity(UserModel model) => UserListItem(
+        id: model.id,
+        name: model.name,
+        email: model.email,
+        phone: model.phone,
+        avatarUrl: model.avatarUrl,
+        isActive: model.isActive,
+      );
+}

--- a/mobile/rupu/lib/domain/infrastructure/models/users_response_model.dart
+++ b/mobile/rupu/lib/domain/infrastructure/models/users_response_model.dart
@@ -1,0 +1,63 @@
+class UsersResponseModel {
+  final bool success;
+  final List<UserModel> data;
+  final int count;
+
+  UsersResponseModel({
+    required this.success,
+    required this.data,
+    required this.count,
+  });
+
+  factory UsersResponseModel.fromJson(Map<String, dynamic> json) {
+    return UsersResponseModel(
+      success: json['success'] as bool,
+      data: (json['data'] as List<dynamic>)
+          .map((e) => UserModel.fromJson(e as Map<String, dynamic>))
+          .toList(),
+      count: json['count'] as int,
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+        'success': success,
+        'data': data.map((e) => e.toJson()).toList(),
+        'count': count,
+      };
+}
+
+class UserModel {
+  final int id;
+  final String name;
+  final String email;
+  final String phone;
+  final String avatarUrl;
+  final bool isActive;
+
+  UserModel({
+    required this.id,
+    required this.name,
+    required this.email,
+    required this.phone,
+    required this.avatarUrl,
+    required this.isActive,
+  });
+
+  factory UserModel.fromJson(Map<String, dynamic> json) => UserModel(
+        id: json['id'] as int,
+        name: json['name'] as String,
+        email: json['email'] as String,
+        phone: json['phone'] as String? ?? '',
+        avatarUrl: json['avatar_url'] as String? ?? '',
+        isActive: json['is_active'] as bool? ?? false,
+      );
+
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'name': name,
+        'email': email,
+        'phone': phone,
+        'avatar_url': avatarUrl,
+        'is_active': isActive,
+      };
+}

--- a/mobile/rupu/lib/domain/infrastructure/repositories/users_repository_impl.dart
+++ b/mobile/rupu/lib/domain/infrastructure/repositories/users_repository_impl.dart
@@ -1,0 +1,38 @@
+import '../../datasource/user_management_datasource.dart';
+import '../../entities/user_list_item.dart';
+import '../../repositories/users_repository.dart';
+import '../mappers/users_mapper.dart';
+
+class UsersRepositoryImpl extends UsersRepository {
+  final UserManagementDatasource datasource;
+  UsersRepositoryImpl(this.datasource);
+
+  @override
+  Future<List<UserListItem>> getUsers({Map<String, dynamic>? query}) async {
+    final res = await datasource.getUsers(query: query);
+    return res.data.map(UsersMapper.userModelToEntity).toList();
+  }
+
+  @override
+  Future<void> createUser({
+    required String name,
+    required String email,
+    String? phone,
+    bool isActive = true,
+    List<int>? roleIds,
+    List<int>? businessIds,
+    String? avatarUrl,
+    String? avatarPath,
+  }) {
+    return datasource.createUser(
+      name: name,
+      email: email,
+      phone: phone,
+      isActive: isActive,
+      roleIds: roleIds,
+      businessIds: businessIds,
+      avatarUrl: avatarUrl,
+      avatarPath: avatarPath,
+    );
+  }
+}

--- a/mobile/rupu/lib/domain/repositories/users_repository.dart
+++ b/mobile/rupu/lib/domain/repositories/users_repository.dart
@@ -1,0 +1,15 @@
+import '../entities/user_list_item.dart';
+
+abstract class UsersRepository {
+  Future<List<UserListItem>> getUsers({Map<String, dynamic>? query});
+  Future<void> createUser({
+    required String name,
+    required String email,
+    String? phone,
+    bool isActive = true,
+    List<int>? roleIds,
+    List<int>? businessIds,
+    String? avatarUrl,
+    String? avatarPath,
+  });
+}

--- a/mobile/rupu/lib/presentation/screens/screens.dart
+++ b/mobile/rupu/lib/presentation/screens/screens.dart
@@ -9,3 +9,4 @@ export 'package:rupu/presentation/screens/cambiar_contrasena/cambiar_contrasena_
 export 'package:rupu/presentation/screens/login/login_screen.dart';
 
 export 'package:rupu/presentation/screens/settings/settings_screen.dart';
+export 'package:rupu/presentation/screens/users/users_screen.dart';

--- a/mobile/rupu/lib/presentation/screens/users/users_screen.dart
+++ b/mobile/rupu/lib/presentation/screens/users/users_screen.dart
@@ -1,0 +1,13 @@
+import 'package:flutter/material.dart';
+import '../../views/users/users_view.dart';
+
+class UsersScreen extends StatelessWidget {
+  static const name = 'users-screen';
+  final int pageIndex;
+  const UsersScreen({super.key, required this.pageIndex});
+
+  @override
+  Widget build(BuildContext context) {
+    return UsersView(pageIndex: pageIndex);
+  }
+}

--- a/mobile/rupu/lib/presentation/views/settings/controllers/create_user_controller.dart
+++ b/mobile/rupu/lib/presentation/views/settings/controllers/create_user_controller.dart
@@ -1,4 +1,77 @@
 // presentation/views/settings/create_user_controller.dart
+import 'package:file_picker/file_picker.dart';
+import 'package:flutter/material.dart';
 import 'package:get/get.dart';
+import 'package:rupu/domain/infrastructure/datasources/users_management_datasource_impl.dart';
+import 'package:rupu/domain/infrastructure/repositories/users_repository_impl.dart';
+import 'package:rupu/domain/repositories/users_repository.dart';
 
-class CreateUserController extends GetxController {}
+class CreateUserController extends GetxController {
+  final UsersRepository repository;
+  CreateUserController()
+      : repository = UsersRepositoryImpl(UsersManagementDatasourceImpl());
+
+  final formKey = GlobalKey<FormState>();
+  final nameCtrl = TextEditingController();
+  final emailCtrl = TextEditingController();
+  final phoneCtrl = TextEditingController();
+  final avatarUrlCtrl = TextEditingController();
+  final roleIdsCtrl = TextEditingController();
+  final businessIdsCtrl = TextEditingController();
+
+  final isActive = true.obs;
+  final Rxn<PlatformFile> avatarFile = Rxn();
+  final isSubmitting = false.obs;
+  final errorMessage = RxnString();
+
+  List<int> _parseIds(String input) {
+    return input
+        .split(',')
+        .map((e) => int.tryParse(e.trim()))
+        .whereType<int>()
+        .toList();
+  }
+
+  Future<void> pickAvatar() async {
+    final result = await FilePicker.platform.pickFiles(type: FileType.image);
+    if (result != null && result.files.isNotEmpty) {
+      avatarFile.value = result.files.first;
+    }
+  }
+
+  Future<bool> submit() async {
+    if (!formKey.currentState!.validate()) return false;
+    isSubmitting.value = true;
+    errorMessage.value = null;
+    try {
+      await repository.createUser(
+        name: nameCtrl.text.trim(),
+        email: emailCtrl.text.trim(),
+        phone: phoneCtrl.text.trim().isEmpty ? null : phoneCtrl.text.trim(),
+        isActive: isActive.value,
+        roleIds: _parseIds(roleIdsCtrl.text),
+        businessIds: _parseIds(businessIdsCtrl.text),
+        avatarUrl:
+            avatarUrlCtrl.text.trim().isEmpty ? null : avatarUrlCtrl.text.trim(),
+        avatarPath: avatarFile.value?.path,
+      );
+      return true;
+    } catch (_) {
+      errorMessage.value = 'Error al crear usuario';
+      return false;
+    } finally {
+      isSubmitting.value = false;
+    }
+  }
+
+  @override
+  void onClose() {
+    nameCtrl.dispose();
+    emailCtrl.dispose();
+    phoneCtrl.dispose();
+    avatarUrlCtrl.dispose();
+    roleIdsCtrl.dispose();
+    businessIdsCtrl.dispose();
+    super.onClose();
+  }
+}

--- a/mobile/rupu/lib/presentation/views/settings/views/create_user_view.dart
+++ b/mobile/rupu/lib/presentation/views/settings/views/create_user_view.dart
@@ -10,9 +10,89 @@ class CreateUserView extends GetView<CreateUserController> {
 
   @override
   Widget build(BuildContext context) {
+    final tt = Theme.of(context).textTheme;
     return Scaffold(
       appBar: AppBar(title: const Text('Crear usuario')),
-      body: const Center(child: Text('Vista de creación de usuario')),
+      body: Form(
+        key: controller.formKey,
+        child: ListView(
+          padding: const EdgeInsets.all(16),
+          children: [
+            TextFormField(
+              controller: controller.nameCtrl,
+              decoration: const InputDecoration(labelText: 'Nombre'),
+              validator: (v) => (v == null || v.isEmpty) ? 'Requerido' : null,
+            ),
+            const SizedBox(height: 12),
+            TextFormField(
+              controller: controller.emailCtrl,
+              decoration: const InputDecoration(labelText: 'Email'),
+              validator: (v) => (v == null || v.isEmpty) ? 'Requerido' : null,
+            ),
+            const SizedBox(height: 12),
+            TextFormField(
+              controller: controller.phoneCtrl,
+              decoration: const InputDecoration(labelText: 'Teléfono'),
+              keyboardType: TextInputType.phone,
+            ),
+            const SizedBox(height: 12),
+            Obx(() => SwitchListTile(
+                  title: const Text('Activo'),
+                  value: controller.isActive.value,
+                  onChanged: (v) => controller.isActive.value = v,
+                )),
+            const SizedBox(height: 12),
+            TextFormField(
+              controller: controller.roleIdsCtrl,
+              decoration:
+                  const InputDecoration(labelText: 'IDs de roles (comma sep)'),
+            ),
+            const SizedBox(height: 12),
+            TextFormField(
+              controller: controller.businessIdsCtrl,
+              decoration: const InputDecoration(
+                  labelText: 'IDs de negocios (comma sep)'),
+            ),
+            const SizedBox(height: 12),
+            TextFormField(
+              controller: controller.avatarUrlCtrl,
+              decoration: const InputDecoration(labelText: 'URL de avatar'),
+            ),
+            const SizedBox(height: 12),
+            Obx(() => ListTile(
+                  title: Text(controller.avatarFile.value?.name ??
+                      'Seleccionar archivo de avatar'),
+                  trailing: const Icon(Icons.attach_file),
+                  onTap: controller.pickAvatar,
+                )),
+            const SizedBox(height: 24),
+            Obx(() => ElevatedButton(
+                  onPressed: controller.isSubmitting.value
+                      ? null
+                      : () async {
+                          final ok = await controller.submit();
+                          if (ok && context.mounted) {
+                            Get.back();
+                          }
+                        },
+                  child: controller.isSubmitting.value
+                      ? const SizedBox(
+                          width: 20,
+                          height: 20,
+                          child: CircularProgressIndicator(strokeWidth: 2),
+                        )
+                      : const Text('Guardar'),
+                )),
+            const SizedBox(height: 8),
+            Obx(() => controller.errorMessage.value != null
+                ? Text(
+                    controller.errorMessage.value!,
+                    style: tt.bodySmall!.copyWith(color: Colors.red),
+                  )
+                : const SizedBox.shrink()),
+          ],
+        ),
+      ),
     );
   }
 }

--- a/mobile/rupu/lib/presentation/views/users/users_controller.dart
+++ b/mobile/rupu/lib/presentation/views/users/users_controller.dart
@@ -1,0 +1,34 @@
+import 'package:get/get.dart';
+import 'package:rupu/domain/entities/user_list_item.dart';
+import 'package:rupu/domain/infrastructure/datasources/users_management_datasource_impl.dart';
+import 'package:rupu/domain/infrastructure/repositories/users_repository_impl.dart';
+import 'package:rupu/domain/repositories/users_repository.dart';
+
+class UsersController extends GetxController {
+  final UsersRepository repository;
+  UsersController()
+      : repository = UsersRepositoryImpl(UsersManagementDatasourceImpl());
+
+  final users = <UserListItem>[].obs;
+  final isLoading = false.obs;
+  final errorMessage = RxnString();
+
+  @override
+  void onReady() {
+    super.onReady();
+    fetchUsers();
+  }
+
+  Future<void> fetchUsers() async {
+    isLoading.value = true;
+    errorMessage.value = null;
+    try {
+      final items = await repository.getUsers();
+      users.assignAll(items);
+    } catch (_) {
+      errorMessage.value = 'No se pudieron cargar los usuarios';
+    } finally {
+      isLoading.value = false;
+    }
+  }
+}

--- a/mobile/rupu/lib/presentation/views/users/users_view.dart
+++ b/mobile/rupu/lib/presentation/views/users/users_view.dart
@@ -1,0 +1,67 @@
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+import 'package:go_router/go_router.dart';
+import '../settings/views/create_user_view.dart';
+import 'users_controller.dart';
+
+class UsersView extends StatefulWidget {
+  static const name = 'users';
+  final int pageIndex;
+  const UsersView({super.key, required this.pageIndex});
+
+  @override
+  State<UsersView> createState() => _UsersViewState();
+}
+
+class _UsersViewState extends State<UsersView> {
+  late final UsersController controller;
+
+  @override
+  void initState() {
+    super.initState();
+    controller = Get.put(UsersController());
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Usuarios'), centerTitle: true),
+      floatingActionButton: FloatingActionButton(
+        onPressed: () => GoRouter.of(context).pushNamed(
+          CreateUserView.name,
+          pathParameters: {'page': '${widget.pageIndex}'},
+        ),
+        child: const Icon(Icons.add),
+      ),
+      body: Obx(() {
+        if (controller.isLoading.value && controller.users.isEmpty) {
+          return const Center(child: CircularProgressIndicator());
+        }
+        final error = controller.errorMessage.value;
+        if (error != null) {
+          return Center(child: Text(error));
+        }
+        return RefreshIndicator(
+          onRefresh: controller.fetchUsers,
+          child: ListView.builder(
+            itemCount: controller.users.length,
+            itemBuilder: (context, index) {
+              final u = controller.users[index];
+              return ListTile(
+                leading: u.avatarUrl.isNotEmpty
+                    ? CircleAvatar(backgroundImage: NetworkImage(u.avatarUrl))
+                    : CircleAvatar(child: Text(u.name.isNotEmpty ? u.name[0] : '?')),
+                title: Text(u.name),
+                subtitle: Text(u.email),
+                trailing: Icon(
+                  u.isActive ? Icons.check_circle : Icons.cancel,
+                  color: u.isActive ? Colors.green : Colors.red,
+                ),
+              );
+            },
+          ),
+        );
+      }),
+    );
+  }
+}

--- a/mobile/rupu/lib/presentation/views/views.dart
+++ b/mobile/rupu/lib/presentation/views/views.dart
@@ -35,3 +35,5 @@ export 'package:rupu/presentation/views/settings/controllers/settings_controller
 export 'package:rupu/presentation/views/settings/views/settings_view.dart';
 export 'package:rupu/presentation/views/settings/controllers/create_user_controller.dart';
 export 'package:rupu/presentation/views/settings/views/create_user_view.dart';
+export 'package:rupu/presentation/views/users/users_controller.dart';
+export 'package:rupu/presentation/views/users/users_view.dart';

--- a/mobile/rupu/lib/presentation/widgets/dashboard.dart
+++ b/mobile/rupu/lib/presentation/widgets/dashboard.dart
@@ -14,6 +14,7 @@ class DashBoard extends StatelessWidget {
       ('Services & Staff', const Design3ServicesStaff()),
       ('Branches', const Design4BranchesManager()),
       ("Today's Schedule", const Design5TodaysSchedule()),
+      ('Usuarios', UsersScreen(pageIndex: pageIndex)),
     ];
 
     return DefaultTabController(

--- a/mobile/rupu/pubspec.yaml
+++ b/mobile/rupu/pubspec.yaml
@@ -47,6 +47,7 @@ dependencies:
   syncfusion_localizations: ^30.2.4
   url_launcher: ^6.3.2
   font_awesome_flutter: ^10.9.0
+  file_picker: ^8.0.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- add users module with datasource, repository and entity mapping
- display users list with creation form allowing avatar upload or URL
- wire users tab and routes into dashboard and router

## Testing
- `flutter pub get` *(fails: command not found)*
- `dart format lib` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c7957b6f28832a99c730d063afc655