### PR TITLE
Allow debugger connection via cleartext traffic in debug/profile

### DIFF
--- a/mobile/rupu/android/app/src/debug/AndroidManifest.xml
+++ b/mobile/rupu/android/app/src/debug/AndroidManifest.xml
@@ -4,4 +4,11 @@
          to allow setting breakpoints, to provide hot reload, etc.
     -->
     <uses-permission android:name="android.permission.INTERNET"/>
+
+    <!--
+      Permite tráfico sin cifrar hacia 127.0.0.1/localhost, necesario para que
+      el depurador de Flutter se conecte al VM service y habilite los puntos de
+      interrupción durante el desarrollo.
+    -->
+    <application android:usesCleartextTraffic="true"/>
 </manifest>

--- a/mobile/rupu/android/app/src/profile/AndroidManifest.xml
+++ b/mobile/rupu/android/app/src/profile/AndroidManifest.xml
@@ -4,4 +4,11 @@
          to allow setting breakpoints, to provide hot reload, etc.
     -->
     <uses-permission android:name="android.permission.INTERNET"/>
+
+    <!--
+      Permite tráfico sin cifrar hacia 127.0.0.1/localhost, necesario para que
+      el depurador de Flutter se conecte al VM service y habilite los puntos de
+      interrupción mientras se ejecuta en modo profile.
+    -->
+    <application android:usesCleartextTraffic="true"/>
 </manifest>


### PR DESCRIPTION
## Summary
- allow cleartext HTTP traffic in the Android debug manifest so Flutter's VM service can be reached from the tooling
- mirror the same cleartext allowance for the profile manifest to keep breakpoints working in profile builds

## Testing
- not run (Flutter SDK not available in container)

------
https://chatgpt.com/codex/tasks/task_e_68ce552e1b4c832a8baa9965db614f2e