### PR TITLE
Fix create user route selection

### DIFF
--- a/mobile/rupu/lib/config/routers/app_router.dart
+++ b/mobile/rupu/lib/config/routers/app_router.dart
@@ -137,6 +137,20 @@ final appRouter = GoRouter(
           },
         ),
         GoRoute(
+          path: '/home/:page/users/create',
+          name: CreateUserView.name,
+          builder: (context, state) {
+            CreateUserBinding.register();
+            final home = Get.find<HomeController>();
+            if (!home.isSuper) {
+              return const Scaffold(
+                body: Center(child: Text('No autorizado')),
+              );
+            }
+            return const CreateUserView();
+          },
+        ),
+        GoRoute(
           path: '/home/:page/users/:id',
           name: UserDetailView.name,
           builder: (context, state) {
@@ -157,20 +171,6 @@ final appRouter = GoRouter(
                 return UserDetailView(userId: id);
               },
             );
-          },
-        ),
-        GoRoute(
-          path: '/home/:page/users/create',
-          name: CreateUserView.name,
-          builder: (context, state) {
-            CreateUserBinding.register();
-            final home = Get.find<HomeController>();
-            if (!home.isSuper) {
-              return const Scaffold(
-                body: Center(child: Text('No autorizado')),
-              );
-            }
-            return const CreateUserView();
           },
         ),
         GoRoute(


### PR DESCRIPTION
## Summary
- place the create-user route before the user-detail route to avoid matching the detail handler when the id is "create"

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cfac85941c832ab88ed0f0056a6fe9