### PR TITLE
fix(business-type): evitar 500 al crear tipo de negocio con código nuevo

### DIFF
--- a/back/central-reserve/services/auth/business/internal/infra/secondary/repository/business_type_repository.go
+++ b/back/central-reserve/services/auth/business/internal/infra/secondary/repository/business_type_repository.go
@@ -3,8 +3,15 @@ package repository
 import (
 	"central_reserve/services/auth/business/internal/domain"
 	"context"
+	"errors"
 	"fmt"
+
+	"gorm.io/gorm"
 )
+
+// errBusinessTypeNotFound es el error que la capa de aplicación espera cuando
+// un tipo de negocio no existe (no es un fallo fatal, indica "código disponible").
+var errBusinessTypeNotFound = errors.New("tipo de negocio no encontrado")
 
 // BusinessTypeRepository implementa ports.IBusinessTypeRepository
 
@@ -32,6 +39,10 @@ func (r *Repository) GetBusinessTypeByID(ctx context.Context, id uint) (*domain.
 func (r *Repository) GetBusinessTypeByCode(ctx context.Context, code string) (*domain.BusinessType, error) {
 	var businessType domain.BusinessType
 	if err := r.database.Conn(ctx).Table("business_type").Where("code = ?", code).First(&businessType).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			// No es un error fatal: el código no existe (disponible para crear).
+			return nil, errBusinessTypeNotFound
+		}
 		r.logger.Error().Str("code", code).Err(err).Msg("Error al obtener tipo de negocio por código")
 		return nil, err
 	}


### PR DESCRIPTION
## Problema
Crear un **Tipo de Negocio** en producción devolvía siempre **HTTP 500** cuando el código no existía previamente (el caso normal al crear uno nuevo).

## Causa raíz
`GetBusinessTypeByCode` (repositorio) devolvía el error crudo de GORM `record not found`. El use case `CreateBusinessType` valida disponibilidad del código comparando el mensaje contra el texto exacto `"tipo de negocio no encontrado"`. Como nunca coincidía, trataba el "no encontrado" como error fatal → 500.

## Fix
El repositorio traduce `gorm.ErrRecordNotFound` al error esperado por la capa de aplicación. Así el use case interpreta "código disponible" y procede a crear.

## Verificación
- Reproducido contra prod: `POST /api/v1/business-types` con business token + `code` nuevo → 500 (antes del fix).
- `go build ./services/auth/business/...` y `go vet` OK.
- Al mergear, `backend-ci-cd.yml` construye y despliega vía OIDC + SSM.

🤖 Generated with [Claude Code](https://claude.com/claude-code)